### PR TITLE
feat: username requirements check

### DIFF
--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -66,8 +66,21 @@ export class MethodsController {
   }
 
   @Get(':id')
-  async findMethodDetailsWithProfit(@Param('id') id: string) {
-    const method = (await this.svc.findMethodDetailsWithProfit(id)) as object; // Replace 'object' with the actual expected type if available
+  async findMethodDetailsWithProfit(@Param('id') id: string, @Query('username') username?: string) {
+    let userInfo: UserInfo | null = null;
+    if (username) {
+      try {
+        userInfo = (await this.runescapeApi.fetchUserInfo(username)) as UserInfo;
+      } catch (error: unknown) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        console.error('Error fetching levels for username:', username, err.message);
+      }
+    }
+
+    const method = (await this.svc.findMethodDetailsWithProfit(
+      id,
+      userInfo || undefined,
+    )) as object;
     return { data: method };
   }
 


### PR DESCRIPTION
## Summary
- add endpoint query param for method detail to accept username
- compute missing requirements per variant when username is supplied

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684740fb1280832f917e2bed9f4c5ccb