### PR TITLE
Implement variant-specific update endpoint

### DIFF
--- a/src/methods/dto/index.ts
+++ b/src/methods/dto/index.ts
@@ -4,3 +4,5 @@ export * from './create-variant.dto';
 export * from './io-item.dto';
 export * from './update-method.dto';
 export * from './method-response.dto';
+export * from './update-method-basic.dto';
+export * from './update-variant.dto';

--- a/src/methods/dto/update-method-basic.dto.ts
+++ b/src/methods/dto/update-method-basic.dto.ts
@@ -1,0 +1,9 @@
+// src/methods/dto/update-method-basic.dto.ts
+import { IsOptional, IsString, IsArray } from 'class-validator';
+
+export class UpdateMethodBasicDto {
+  @IsOptional() @IsString() name?: string;
+  @IsOptional() @IsString() description?: string;
+  @IsOptional() @IsString() category?: string;
+  @IsOptional() @IsArray() @IsString({ each: true }) variants?: string[];
+}

--- a/src/methods/dto/update-variant.dto.ts
+++ b/src/methods/dto/update-variant.dto.ts
@@ -1,0 +1,27 @@
+// src/methods/dto/update-variant.dto.ts
+import { IsString, IsOptional, IsNumber, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IoItemDto } from './io-item.dto';
+
+export class UpdateVariantDto {
+  @IsOptional() @IsString() label?: string;
+  @IsOptional() @IsNumber() actionsPerHour?: number;
+  @IsOptional() xpHour?: object;
+  @IsOptional() @IsNumber() clickIntensity?: number;
+  @IsOptional() @IsNumber() afkiness?: number;
+  @IsOptional() @IsString() riskLevel?: string;
+  @IsOptional() requirements?: object;
+  @IsOptional() recommendations?: object;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => IoItemDto)
+  inputs?: IoItemDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => IoItemDto)
+  outputs?: IoItemDto[];
+}

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -1,6 +1,11 @@
 import { Controller, Get, Post, Put, Delete, Param, Body, Query } from '@nestjs/common';
 import { MethodsService } from './methods.service';
-import { CreateMethodDto, UpdateMethodDto } from './dto';
+import {
+  CreateMethodDto,
+  UpdateMethodDto,
+  UpdateMethodBasicDto,
+  UpdateVariantDto,
+} from './dto';
 import { RuneScapeApiService } from './RuneScapeApiService';
 
 interface PaginatedResult {
@@ -87,6 +92,24 @@ export class MethodsController {
   @Put(':id')
   async update(@Param('id') id: string, @Body() dto: UpdateMethodDto) {
     const updated = await this.svc.update(id, dto);
+    return { data: updated };
+  }
+
+  @Put(':id/basic')
+  async updateBasic(
+    @Param('id') id: string,
+    @Body() dto: UpdateMethodBasicDto,
+  ) {
+    const updated = await this.svc.updateBasic(id, dto);
+    return { data: updated };
+  }
+
+  @Put('variant/:id')
+  async updateVariant(
+    @Param('id') id: string,
+    @Body() dto: UpdateVariantDto,
+  ) {
+    const updated = await this.svc.updateVariant(id, dto);
     return { data: updated };
   }
 


### PR DESCRIPTION
## Summary
- support updating basic method data separately from variants
- support editing a single variant of a method

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c467fecf0832fa5a059931edea4e1