### PR TITLE
Implement variant snapshot feature

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { MethodProfitRefresherModule } from './method-profit-refresher/method-pr
 // Si tienes un PricesModule que se conecta a Redis, impórtalo también aquí:
 import { PricesModule } from './prices/prices.module';
 import { VariantHistoryModule } from './variant-history/variant-history.module';
+import { VariantSnapshotsModule } from './variant-snapshots/variant-snapshots.module';
 
 @Module({
   imports: [
@@ -44,6 +45,9 @@ import { VariantHistoryModule } from './variant-history/variant-history.module';
 
     // Guardar historial de profits cada 5 minutos:
     VariantHistoryModule,
+
+    // Endpoints para snapshots de variantes
+    VariantSnapshotsModule,
 
     // Si antes tenías un PricesModule para Redis, vuelve a importarlo:
     PricesModule,

--- a/src/methods/dto/update-variant.dto.ts
+++ b/src/methods/dto/update-variant.dto.ts
@@ -24,4 +24,16 @@ export class UpdateVariantDto {
   @ValidateNested({ each: true })
   @Type(() => IoItemDto)
   outputs?: IoItemDto[];
+
+  // Snapshot fields
+  @IsOptional()
+  @IsString()
+  snapshotName?: string;
+
+  @IsOptional()
+  @IsString()
+  snapshotDescription?: string;
+
+  @IsOptional()
+  snapshotDate?: string;
 }

--- a/src/methods/entities/variant-snapshot.entity.ts
+++ b/src/methods/entities/variant-snapshot.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { MethodVariant } from './variant.entity';
+
+@Entity('variant_snapshots')
+export class VariantSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => MethodVariant, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'variant_id' })
+  variant: MethodVariant;
+
+  @Column()
+  label: string;
+
+  @Column({ name: 'xp_hour', type: 'jsonb', nullable: true })
+  xpHour: any;
+
+  @Column({ name: 'click_intensity', type: 'int', nullable: true })
+  clickIntensity: number;
+
+  @Column({ name: 'afkiness', type: 'int', nullable: true })
+  afkiness: number;
+
+  @Column({ name: 'risk_level', nullable: true })
+  riskLevel: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  requirements: any;
+
+  @Column({ type: 'jsonb', nullable: true })
+  recommendations: any;
+
+  @Column({ name: 'actions_per_hour', type: 'int', nullable: true })
+  actionsPerHour: number;
+
+  @Column({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ name: 'snapshot_name' })
+  snapshotName: string;
+
+  @Column({ name: 'snapshot_description', nullable: true })
+  snapshotDescription?: string;
+
+  @Column({ name: 'snapshot_date', type: 'timestamptz' })
+  snapshotDate: Date;
+}

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -108,8 +108,13 @@ export class MethodsController {
   async updateVariant(
     @Param('id') id: string,
     @Body() dto: UpdateVariantDto,
+    @Query('generateSnapshot') generateSnapshot?: string,
   ) {
-    const updated = await this.svc.updateVariant(id, dto);
+    const updated = await this.svc.updateVariant(
+      id,
+      dto,
+      generateSnapshot === 'true',
+    );
     return { data: updated };
   }
 

--- a/src/methods/methods.module.ts
+++ b/src/methods/methods.module.ts
@@ -6,10 +6,13 @@ import { MethodsController } from './methods.controller';
 import { Method } from './entities/method.entity';
 import { MethodVariant } from './entities/variant.entity';
 import { VariantIoItem } from './entities/io-item.entity';
+import { VariantSnapshot } from './entities/variant-snapshot.entity';
 import { RuneScapeApiService } from './RuneScapeApiService';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Method, MethodVariant, VariantIoItem])],
+  imports: [
+    TypeOrmModule.forFeature([Method, MethodVariant, VariantIoItem, VariantSnapshot]),
+  ],
   providers: [MethodsService, RuneScapeApiService],
   controllers: [MethodsController],
   exports: [MethodsService], // ← añade esta línea

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -4,6 +4,7 @@ import { Repository, In } from 'typeorm';
 import { Method } from './entities/method.entity';
 import { MethodVariant } from './entities/variant.entity';
 import { VariantIoItem } from './entities/io-item.entity';
+import { VariantSnapshot } from './entities/variant-snapshot.entity';
 import { CreateMethodDto } from './dto/create-method.dto';
 import { UpdateMethodDto } from './dto/update-method.dto';
 import { UpdateMethodBasicDto } from './dto/update-method-basic.dto';
@@ -169,6 +170,9 @@ export class MethodsService implements OnModuleDestroy {
 
     @InjectRepository(VariantIoItem)
     private readonly ioRepo: Repository<VariantIoItem>,
+
+    @InjectRepository(VariantSnapshot)
+    private readonly snapshotRepo: Repository<VariantSnapshot>,
   ) {
     this.redis = new IORedis(process.env.REDIS_URL as string);
   }
@@ -275,13 +279,24 @@ export class MethodsService implements OnModuleDestroy {
     return this.toDto(reloaded!);
   }
 
-  async updateVariant(id: string, dto: UpdateVariantDto): Promise<MethodDto> {
+  async updateVariant(
+    id: string,
+    dto: UpdateVariantDto,
+    generateSnapshot = false,
+  ): Promise<MethodDto> {
     const variant = await this.variantRepo.findOne({
       where: { id },
       relations: ['ioItems', 'method'],
     });
     if (!variant) throw new NotFoundException(`Variant ${id} not found`);
-    const { inputs = [], outputs = [], ...rest } = dto;
+    const {
+      inputs = [],
+      outputs = [],
+      snapshotName,
+      snapshotDescription,
+      snapshotDate,
+      ...rest
+    } = dto;
     Object.assign(variant, rest);
 
     // Remove existing IO items to avoid duplicates
@@ -311,6 +326,29 @@ export class MethodsService implements OnModuleDestroy {
 
     variant.ioItems = newItems;
     await this.variantRepo.save(variant);
+
+    if (generateSnapshot) {
+      if (!snapshotName) {
+        throw new Error('snapshotName is required when generateSnapshot is true');
+      }
+      const snap = this.snapshotRepo.create({
+        variant,
+        label: variant.label,
+        xpHour: variant.xpHour,
+        clickIntensity: variant.clickIntensity,
+        afkiness: variant.afkiness,
+        riskLevel: variant.riskLevel,
+        requirements: variant.requirements,
+        recommendations: variant.recommendations,
+        actionsPerHour: variant.actionsPerHour,
+        createdAt: variant.createdAt,
+        snapshotName,
+        snapshotDescription,
+        snapshotDate: snapshotDate ? new Date(snapshotDate) : new Date(),
+      });
+      await this.snapshotRepo.save(snap);
+    }
+
     return this.findOne(variant.method.id);
   }
 

--- a/src/variant-snapshots/variant-snapshots.controller.ts
+++ b/src/variant-snapshots/variant-snapshots.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Delete, Param } from '@nestjs/common';
+import { VariantSnapshotsService } from './variant-snapshots.service';
+
+@Controller('variant-snapshots')
+export class VariantSnapshotsController {
+  constructor(private readonly svc: VariantSnapshotsService) {}
+
+  @Delete(':id')
+  async remove(@Param('id') id: string) {
+    await this.svc.remove(id);
+    return { data: null };
+  }
+}

--- a/src/variant-snapshots/variant-snapshots.module.ts
+++ b/src/variant-snapshots/variant-snapshots.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VariantSnapshot } from '../methods/entities/variant-snapshot.entity';
+import { VariantSnapshotsService } from './variant-snapshots.service';
+import { VariantSnapshotsController } from './variant-snapshots.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([VariantSnapshot])],
+  providers: [VariantSnapshotsService],
+  controllers: [VariantSnapshotsController],
+})
+export class VariantSnapshotsModule {}

--- a/src/variant-snapshots/variant-snapshots.service.ts
+++ b/src/variant-snapshots/variant-snapshots.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { VariantSnapshot } from '../methods/entities/variant-snapshot.entity';
+
+@Injectable()
+export class VariantSnapshotsService {
+  constructor(
+    @InjectRepository(VariantSnapshot)
+    private readonly repo: Repository<VariantSnapshot>,
+  ) {}
+
+  async remove(id: string): Promise<void> {
+    const res = await this.repo.delete(id);
+    if (res.affected === 0) {
+      throw new NotFoundException(`Snapshot ${id} not found`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `VariantSnapshot` entity and persistence module
- allow update-variant endpoint to create a snapshot when `generateSnapshot=true`
- support snapshot fields in `UpdateVariantDto`
- expose DELETE endpoint for variant snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c68181aec832f8e55b87d0b6da1ea