### PR TITLE
Add snapshots to variant history endpoint

### DIFF
--- a/src/variant-history/variant-history.controller.ts
+++ b/src/variant-history/variant-history.controller.ts
@@ -11,7 +11,7 @@ export class VariantHistoryController {
     @Query('from') from?: string,
     @Query('to') to?: string,
   ) {
-    const history = await this.svc.getHistory(variantId, from, to);
-    return { data: history };
+    const { history, snapshots } = await this.svc.getHistory(variantId, from, to);
+    return { data: history, variant_snapshot: snapshots };
   }
 }

--- a/src/variant-history/variant-history.module.ts
+++ b/src/variant-history/variant-history.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { VariantHistory } from '../methods/entities/variant-history.entity';
+import { VariantSnapshot } from '../methods/entities/variant-snapshot.entity';
 import { VariantHistoryService } from './variant-history.service';
 import { VariantHistoryController } from './variant-history.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([VariantHistory])],
+  imports: [TypeOrmModule.forFeature([VariantHistory, VariantSnapshot])],
   providers: [VariantHistoryService],
   controllers: [VariantHistoryController],
 })


### PR DESCRIPTION
## Summary
- fetch variant snapshots within a range alongside history
- expose snapshots via `variant_snapshot` field in the history endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb3ff5ef0832f9515269d1c54d307