### PR TITLE
feat/variant-history-daily-aggregates

### DIFF
--- a/sql/2026-07-07-create-variant-history-daily.sql
+++ b/sql/2026-07-07-create-variant-history-daily.sql
@@ -1,0 +1,122 @@
+CREATE TABLE IF NOT EXISTS variant_history_daily (
+  variant_id uuid NOT NULL REFERENCES method_variants(id) ON DELETE CASCADE,
+  bucket_date date NOT NULL,
+  low_profit_sum numeric NOT NULL,
+  high_profit_sum numeric NOT NULL,
+  low_profit_min numeric NOT NULL,
+  low_profit_max numeric NOT NULL,
+  high_profit_min numeric NOT NULL,
+  high_profit_max numeric NOT NULL,
+  open_low_profit numeric NOT NULL,
+  open_high_profit numeric NOT NULL,
+  open_timestamp timestamptz NOT NULL,
+  close_low_profit numeric NOT NULL,
+  close_high_profit numeric NOT NULL,
+  close_timestamp timestamptz NOT NULL,
+  samples integer NOT NULL CHECK (samples > 0),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (variant_id, bucket_date)
+);
+
+DELETE FROM variant_history_daily
+WHERE bucket_date >= (now() AT TIME ZONE 'Europe/London')::date - 30;
+
+WITH filtered AS MATERIALIZED (
+  SELECT
+    variant_id,
+    "timestamp",
+    ("timestamp" AT TIME ZONE 'Europe/London')::date AS bucket_date,
+    low_profit,
+    high_profit
+  FROM variant_history
+  WHERE "timestamp" >= now() - interval '30 days'
+),
+agg AS (
+  SELECT
+    variant_id,
+    bucket_date,
+    SUM(low_profit) AS low_profit_sum,
+    SUM(high_profit) AS high_profit_sum,
+    MIN(low_profit) AS low_profit_min,
+    MAX(low_profit) AS low_profit_max,
+    MIN(high_profit) AS high_profit_min,
+    MAX(high_profit) AS high_profit_max,
+    COUNT(*)::integer AS samples
+  FROM filtered
+  GROUP BY variant_id, bucket_date
+),
+opens AS (
+  SELECT DISTINCT ON (variant_id, bucket_date)
+    variant_id,
+    bucket_date,
+    low_profit AS open_low_profit,
+    high_profit AS open_high_profit,
+    "timestamp" AS open_timestamp
+  FROM filtered
+  ORDER BY variant_id, bucket_date, "timestamp" ASC
+),
+closes AS (
+  SELECT DISTINCT ON (variant_id, bucket_date)
+    variant_id,
+    bucket_date,
+    low_profit AS close_low_profit,
+    high_profit AS close_high_profit,
+    "timestamp" AS close_timestamp
+  FROM filtered
+  ORDER BY variant_id, bucket_date, "timestamp" DESC
+)
+INSERT INTO variant_history_daily (
+  variant_id,
+  bucket_date,
+  low_profit_sum,
+  high_profit_sum,
+  low_profit_min,
+  low_profit_max,
+  high_profit_min,
+  high_profit_max,
+  open_low_profit,
+  open_high_profit,
+  open_timestamp,
+  close_low_profit,
+  close_high_profit,
+  close_timestamp,
+  samples,
+  updated_at
+)
+SELECT
+  agg.variant_id,
+  agg.bucket_date,
+  agg.low_profit_sum,
+  agg.high_profit_sum,
+  agg.low_profit_min,
+  agg.low_profit_max,
+  agg.high_profit_min,
+  agg.high_profit_max,
+  opens.open_low_profit,
+  opens.open_high_profit,
+  opens.open_timestamp,
+  closes.close_low_profit,
+  closes.close_high_profit,
+  closes.close_timestamp,
+  agg.samples,
+  now()
+FROM agg
+JOIN opens USING (variant_id, bucket_date)
+JOIN closes USING (variant_id, bucket_date)
+ON CONFLICT (variant_id, bucket_date) DO UPDATE SET
+  low_profit_sum = EXCLUDED.low_profit_sum,
+  high_profit_sum = EXCLUDED.high_profit_sum,
+  low_profit_min = EXCLUDED.low_profit_min,
+  low_profit_max = EXCLUDED.low_profit_max,
+  high_profit_min = EXCLUDED.high_profit_min,
+  high_profit_max = EXCLUDED.high_profit_max,
+  open_low_profit = EXCLUDED.open_low_profit,
+  open_high_profit = EXCLUDED.open_high_profit,
+  open_timestamp = EXCLUDED.open_timestamp,
+  close_low_profit = EXCLUDED.close_low_profit,
+  close_high_profit = EXCLUDED.close_high_profit,
+  close_timestamp = EXCLUDED.close_timestamp,
+  samples = EXCLUDED.samples,
+  updated_at = now();
+
+DROP INDEX CONCURRENTLY IF EXISTS variant_history_variant_id_timestamp_cover_idx;

--- a/src/methods/entities/variant-history-daily.entity.ts
+++ b/src/methods/entities/variant-history-daily.entity.ts
@@ -1,0 +1,57 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { MethodVariant } from './variant.entity';
+
+@Entity('variant_history_daily')
+export class VariantHistoryDaily {
+  @PrimaryColumn({ name: 'variant_id', type: 'uuid' })
+  variantId: string;
+
+  @ManyToOne(() => MethodVariant, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'variant_id' })
+  variant: MethodVariant;
+
+  @PrimaryColumn({ name: 'bucket_date', type: 'date' })
+  bucketDate: string;
+
+  @Column({ name: 'low_profit_sum', type: 'numeric' })
+  lowProfitSum: number;
+
+  @Column({ name: 'high_profit_sum', type: 'numeric' })
+  highProfitSum: number;
+
+  @Column({ name: 'low_profit_min', type: 'numeric' })
+  lowProfitMin: number;
+
+  @Column({ name: 'low_profit_max', type: 'numeric' })
+  lowProfitMax: number;
+
+  @Column({ name: 'high_profit_min', type: 'numeric' })
+  highProfitMin: number;
+
+  @Column({ name: 'high_profit_max', type: 'numeric' })
+  highProfitMax: number;
+
+  @Column({ name: 'open_low_profit', type: 'numeric' })
+  openLowProfit: number;
+
+  @Column({ name: 'open_high_profit', type: 'numeric' })
+  openHighProfit: number;
+
+  @Column({ name: 'open_timestamp', type: 'timestamptz' })
+  openTimestamp: Date;
+
+  @Column({ name: 'close_low_profit', type: 'numeric' })
+  closeLowProfit: number;
+
+  @Column({ name: 'close_high_profit', type: 'numeric' })
+  closeHighProfit: number;
+
+  @Column({ name: 'close_timestamp', type: 'timestamptz' })
+  closeTimestamp: Date;
+
+  @Column({ type: 'int' })
+  samples: number;
+
+  @Column({ name: 'updated_at', type: 'timestamptz', default: () => 'now()' })
+  updatedAt: Date;
+}

--- a/src/variant-history/variant-history.module.ts
+++ b/src/variant-history/variant-history.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { VariantHistory } from '../methods/entities/variant-history.entity';
+import { VariantHistoryDaily } from '../methods/entities/variant-history-daily.entity';
 import { VariantSnapshot } from '../methods/entities/variant-snapshot.entity';
 import { VariantHistoryService } from './variant-history.service';
 import { VariantHistoryController } from './variant-history.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([VariantHistory, VariantSnapshot])],
+  imports: [TypeOrmModule.forFeature([VariantHistory, VariantHistoryDaily, VariantSnapshot])],
   providers: [VariantHistoryService],
   controllers: [VariantHistoryController],
 })

--- a/src/variant-history/variant-history.service.spec.ts
+++ b/src/variant-history/variant-history.service.spec.ts
@@ -1,0 +1,185 @@
+import type { ConfigService } from '@nestjs/config';
+import type { Repository } from 'typeorm';
+import { VariantHistoryDaily } from '../methods/entities/variant-history-daily.entity';
+import { VariantHistory } from '../methods/entities/variant-history.entity';
+import { VariantSnapshot } from '../methods/entities/variant-snapshot.entity';
+import { HistoryGranularity, HistoryRange } from './dto/variant-history-query.dto';
+import { VariantHistoryService } from './variant-history.service';
+
+const redisCall = jest.fn();
+
+jest.mock('ioredis', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({ call: redisCall })),
+}));
+
+const createSnapshotRepo = (): Repository<VariantSnapshot> => {
+  const queryBuilder = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
+  };
+
+  return {
+    createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+  } as unknown as Repository<VariantSnapshot>;
+};
+
+const createHistoryRepo = () => {
+  const queryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    getRawOne: jest.fn().mockResolvedValue({ min: '2025-08-27T19:25:00.048Z' }),
+  };
+  const create = jest.fn((value: VariantHistory) => value);
+  const save = jest.fn().mockResolvedValue([]);
+  const query = jest.fn().mockResolvedValue([
+    {
+      bucket: new Date('2026-01-01T00:00:00.000Z'),
+      low_profit: 10,
+      high_profit: 20,
+    },
+  ]);
+  const createQueryBuilder = jest.fn().mockReturnValue(queryBuilder);
+
+  return {
+    repo: {
+      create,
+      save,
+      query,
+      createQueryBuilder,
+    } as unknown as Repository<VariantHistory>,
+    create,
+    save,
+    query,
+    createQueryBuilder,
+  };
+};
+
+const createDailyHistoryRepo = () => {
+  const query = jest.fn().mockResolvedValue([
+    {
+      bucket: new Date('2026-01-01T00:00:00.000Z'),
+      low_profit: 30,
+      high_profit: 60,
+    },
+  ]);
+
+  return {
+    repo: {
+      query,
+    } as unknown as Repository<VariantHistoryDaily>,
+    query,
+  };
+};
+
+const createService = () => {
+  const historyRepo = createHistoryRepo();
+  const dailyHistoryRepo = createDailyHistoryRepo();
+  const snapshotRepo = createSnapshotRepo();
+  const service = new VariantHistoryService(historyRepo.repo, dailyHistoryRepo.repo, snapshotRepo, {
+    get: jest.fn().mockReturnValue('redis://localhost:6379'),
+  } as unknown as ConfigService);
+
+  return { service, historyRepo, dailyHistoryRepo };
+};
+
+describe('VariantHistoryService', () => {
+  beforeEach(() => {
+    redisCall.mockReset();
+  });
+
+  it('uses daily history for 1y average history', async () => {
+    const { service, historyRepo, dailyHistoryRepo } = createService();
+
+    const result = await service.getHistory('variant-1', {
+      range: HistoryRange.RANGE_1Y,
+      granularity: HistoryGranularity.AUTO,
+    });
+
+    expect(dailyHistoryRepo.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM variant_history_daily'),
+      expect.any(Array),
+    );
+    expect(historyRepo.query).not.toHaveBeenCalled();
+    expect(result.history).toEqual([
+      {
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+        lowProfit: 30,
+        highProfit: 60,
+      },
+    ]);
+  });
+
+  it('uses daily history for all-time average history', async () => {
+    const { service, historyRepo, dailyHistoryRepo } = createService();
+
+    await service.getHistory('variant-1', {
+      range: HistoryRange.RANGE_ALL,
+      granularity: HistoryGranularity.AUTO,
+    });
+
+    expect(historyRepo.createQueryBuilder).toHaveBeenCalled();
+    expect(dailyHistoryRepo.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM variant_history_daily'),
+      expect.any(Array),
+    );
+    expect(historyRepo.query).not.toHaveBeenCalled();
+  });
+
+  it('falls back to raw history for a non-default timezone', async () => {
+    const { service, historyRepo, dailyHistoryRepo } = createService();
+
+    await service.getHistory('variant-1', {
+      range: HistoryRange.RANGE_1Y,
+      granularity: HistoryGranularity.DAY_1,
+      tz: 'UTC',
+    });
+
+    expect(dailyHistoryRepo.query).not.toHaveBeenCalled();
+    expect(historyRepo.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM variant_history'),
+      expect.any(Array),
+    );
+  });
+
+  it('falls back to raw history for 24h history', async () => {
+    const { service, historyRepo, dailyHistoryRepo } = createService();
+
+    await service.getHistory('variant-1', {
+      range: HistoryRange.RANGE_24H,
+      granularity: HistoryGranularity.AUTO,
+    });
+
+    expect(dailyHistoryRepo.query).not.toHaveBeenCalled();
+    expect(historyRepo.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM variant_history'),
+      expect.any(Array),
+    );
+  });
+
+  it('upserts daily history when capturing raw snapshots', async () => {
+    const { service, historyRepo, dailyHistoryRepo } = createService();
+    redisCall.mockResolvedValue([
+      'method-1',
+      JSON.stringify({
+        'variant-1': { low: 100, high: 200 },
+      }),
+    ]);
+
+    await service.capture();
+
+    expect(historyRepo.save).toHaveBeenCalledWith([
+      expect.objectContaining({
+        variant: { id: 'variant-1' },
+        lowProfit: 100,
+        highProfit: 200,
+      }),
+    ]);
+    expect(dailyHistoryRepo.query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (variant_id, bucket_date) DO UPDATE SET'),
+      ['variant-1', expect.any(Date), 100, 200],
+    );
+  });
+});

--- a/src/variant-history/variant-history.service.ts
+++ b/src/variant-history/variant-history.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import Redis from 'ioredis';
 import { VariantHistory } from '../methods/entities/variant-history.entity';
+import { VariantHistoryDaily } from '../methods/entities/variant-history-daily.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
 import { VariantSnapshot } from '../methods/entities/variant-snapshot.entity';
 import { ConfigService } from '@nestjs/config';
@@ -23,6 +24,8 @@ export class VariantHistoryService {
   constructor(
     @InjectRepository(VariantHistory)
     private readonly historyRepo: Repository<VariantHistory>,
+    @InjectRepository(VariantHistoryDaily)
+    private readonly dailyHistoryRepo: Repository<VariantHistoryDaily>,
     @InjectRepository(VariantSnapshot)
     private readonly snapshotRepo: Repository<VariantSnapshot>,
     private readonly config: ConfigService,
@@ -132,8 +135,172 @@ export class VariantHistoryService {
 
     console.log('Saving variant history records:', records);
     await this.historyRepo.save(records);
+    await this.upsertDailyHistory(records);
     console.log('Saved variant history records successfully:', records);
     this.logger.log(`Stored ${records.length} variant profit snapshots`);
+  }
+
+  private async upsertDailyHistory(records: VariantHistory[]): Promise<void> {
+    if (records.length === 0) return;
+
+    const params: unknown[] = [];
+    const valuesSql = records.map((record, index) => {
+      const base = index * 4;
+      params.push(record.variant.id, record.timestamp, record.lowProfit, record.highProfit);
+      return `($${base + 1}::uuid, $${base + 2}::timestamptz, $${base + 3}::numeric, $${base + 4}::numeric)`;
+    });
+
+    await this.dailyHistoryRepo.query(
+      `
+        INSERT INTO variant_history_daily (
+          variant_id,
+          bucket_date,
+          low_profit_sum,
+          high_profit_sum,
+          low_profit_min,
+          low_profit_max,
+          high_profit_min,
+          high_profit_max,
+          open_low_profit,
+          open_high_profit,
+          open_timestamp,
+          close_low_profit,
+          close_high_profit,
+          close_timestamp,
+          samples,
+          updated_at
+        )
+        SELECT
+          input.variant_id,
+          (input.timestamp AT TIME ZONE 'Europe/London')::date AS bucket_date,
+          input.low_profit,
+          input.high_profit,
+          input.low_profit,
+          input.low_profit,
+          input.high_profit,
+          input.high_profit,
+          input.low_profit,
+          input.high_profit,
+          input.timestamp,
+          input.low_profit,
+          input.high_profit,
+          input.timestamp,
+          1,
+          now()
+        FROM (VALUES ${valuesSql.join(', ')}) AS input(
+          variant_id,
+          timestamp,
+          low_profit,
+          high_profit
+        )
+        ON CONFLICT (variant_id, bucket_date) DO UPDATE SET
+          low_profit_sum = variant_history_daily.low_profit_sum + EXCLUDED.low_profit_sum,
+          high_profit_sum = variant_history_daily.high_profit_sum + EXCLUDED.high_profit_sum,
+          low_profit_min = LEAST(variant_history_daily.low_profit_min, EXCLUDED.low_profit_min),
+          low_profit_max = GREATEST(variant_history_daily.low_profit_max, EXCLUDED.low_profit_max),
+          high_profit_min = LEAST(variant_history_daily.high_profit_min, EXCLUDED.high_profit_min),
+          high_profit_max = GREATEST(variant_history_daily.high_profit_max, EXCLUDED.high_profit_max),
+          open_low_profit = CASE
+            WHEN EXCLUDED.open_timestamp < variant_history_daily.open_timestamp
+              THEN EXCLUDED.open_low_profit
+            ELSE variant_history_daily.open_low_profit
+          END,
+          open_high_profit = CASE
+            WHEN EXCLUDED.open_timestamp < variant_history_daily.open_timestamp
+              THEN EXCLUDED.open_high_profit
+            ELSE variant_history_daily.open_high_profit
+          END,
+          open_timestamp = LEAST(variant_history_daily.open_timestamp, EXCLUDED.open_timestamp),
+          close_low_profit = CASE
+            WHEN EXCLUDED.close_timestamp > variant_history_daily.close_timestamp
+              THEN EXCLUDED.close_low_profit
+            ELSE variant_history_daily.close_low_profit
+          END,
+          close_high_profit = CASE
+            WHEN EXCLUDED.close_timestamp > variant_history_daily.close_timestamp
+              THEN EXCLUDED.close_high_profit
+            ELSE variant_history_daily.close_high_profit
+          END,
+          close_timestamp = GREATEST(variant_history_daily.close_timestamp, EXCLUDED.close_timestamp),
+          samples = variant_history_daily.samples + EXCLUDED.samples,
+          updated_at = now()
+      `,
+      params,
+    );
+  }
+
+  private shouldUseDailyHistory(
+    range: HistoryRange,
+    granularity: HistoryGranularity,
+    tz: string,
+  ): boolean {
+    const isLongRange = range === HistoryRange.RANGE_1Y || range === HistoryRange.RANGE_ALL;
+    const isDefaultTimezone = tz.trim().toLowerCase() === 'europe/london';
+    const isDailyOrLarger =
+      granularity === HistoryGranularity.DAY_1 ||
+      granularity === HistoryGranularity.WEEK_1 ||
+      granularity === HistoryGranularity.MONTH_1;
+
+    return isLongRange && isDefaultTimezone && isDailyOrLarger;
+  }
+
+  private buildDailyBucketExpression(granularity: HistoryGranularity): string {
+    if (granularity === HistoryGranularity.DAY_1) {
+      return "bucket_date::timestamp AT TIME ZONE 'Europe/London'";
+    }
+
+    const trunc = granularity === HistoryGranularity.WEEK_1 ? 'week' : 'month';
+    return `date_trunc('${trunc}', bucket_date::timestamp) AT TIME ZONE 'Europe/London'`;
+  }
+
+  private async queryDailyHistory(
+    variantId: string,
+    from: Date,
+    to: Date,
+    granularity: HistoryGranularity,
+    agg: HistoryAgg,
+  ): Promise<Record<string, unknown>[]> {
+    const bucketExpr = this.buildDailyBucketExpression(granularity);
+
+    let selectClause = '';
+    if (agg === HistoryAgg.AVG) {
+      selectClause = `
+        ${bucketExpr} AS bucket,
+        (SUM(low_profit_sum) / NULLIF(SUM(samples), 0))::float AS low_profit,
+        (SUM(high_profit_sum) / NULLIF(SUM(samples), 0))::float AS high_profit
+      `;
+    } else if (agg === HistoryAgg.CLOSE) {
+      selectClause = `
+        ${bucketExpr} AS bucket,
+        (ARRAY_AGG(close_low_profit ORDER BY close_timestamp DESC))[1]::float AS low_profit,
+        (ARRAY_AGG(close_high_profit ORDER BY close_timestamp DESC))[1]::float AS high_profit
+      `;
+    } else {
+      selectClause = `
+        ${bucketExpr} AS bucket,
+        (ARRAY_AGG(open_low_profit ORDER BY open_timestamp ASC))[1]::float AS open_low,
+        MAX(low_profit_max)::float AS high_low,
+        MIN(low_profit_min)::float AS low_low,
+        (ARRAY_AGG(close_low_profit ORDER BY close_timestamp DESC))[1]::float AS close_low,
+        (ARRAY_AGG(open_high_profit ORDER BY open_timestamp ASC))[1]::float AS open_high,
+        MAX(high_profit_max)::float AS high_high,
+        MIN(high_profit_min)::float AS low_high,
+        (ARRAY_AGG(close_high_profit ORDER BY close_timestamp DESC))[1]::float AS close_high
+      `;
+    }
+
+    return this.dailyHistoryRepo.query(
+      `
+        SELECT ${selectClause}
+        FROM variant_history_daily
+        WHERE variant_id = $1
+          AND bucket_date >= ($2::timestamptz AT TIME ZONE 'Europe/London')::date
+          AND bucket_date <= ($3::timestamptz AT TIME ZONE 'Europe/London')::date
+        GROUP BY bucket
+        ORDER BY bucket
+      `,
+      [variantId, from.toISOString(), to.toISOString()],
+    );
   }
 
   async getHistory(
@@ -203,64 +370,69 @@ export class VariantHistoryService {
       }
     }
 
-    const params: any[] = [variantId, from.toISOString(), now.toISOString()];
-
-    let bucketExpr = '';
-    if (
-      granularity === HistoryGranularity.MIN_10 ||
-      granularity === HistoryGranularity.MIN_30 ||
-      granularity === HistoryGranularity.HOUR_2
-    ) {
-      const sec = granSecs[granularity];
-      bucketExpr = `to_timestamp(floor(extract(epoch from timestamp) / ${sec}) * ${sec})`;
+    let rows: Record<string, unknown>[];
+    if (this.shouldUseDailyHistory(range, granularity, tz)) {
+      rows = await this.queryDailyHistory(variantId, from, now, granularity, agg);
     } else {
-      const trunc =
-        granularity === HistoryGranularity.DAY_1
-          ? 'day'
-          : granularity === HistoryGranularity.WEEK_1
-            ? 'week'
-            : 'month';
-      const paramIndex = params.length + 1;
-      bucketExpr = `date_trunc('${trunc}', timestamp AT TIME ZONE $${paramIndex}) AT TIME ZONE $${paramIndex}`;
-      params.push(tz);
+      const params: any[] = [variantId, from.toISOString(), now.toISOString()];
+
+      let bucketExpr = '';
+      if (
+        granularity === HistoryGranularity.MIN_10 ||
+        granularity === HistoryGranularity.MIN_30 ||
+        granularity === HistoryGranularity.HOUR_2
+      ) {
+        const sec = granSecs[granularity];
+        bucketExpr = `to_timestamp(floor(extract(epoch from timestamp) / ${sec}) * ${sec})`;
+      } else {
+        const trunc =
+          granularity === HistoryGranularity.DAY_1
+            ? 'day'
+            : granularity === HistoryGranularity.WEEK_1
+              ? 'week'
+              : 'month';
+        const paramIndex = params.length + 1;
+        bucketExpr = `date_trunc('${trunc}', timestamp AT TIME ZONE $${paramIndex}) AT TIME ZONE $${paramIndex}`;
+        params.push(tz);
+      }
+
+      let selectClause = '';
+      if (agg === HistoryAgg.AVG) {
+        selectClause = `
+          ${bucketExpr} AS bucket,
+          AVG(low_profit)::float AS low_profit,
+          AVG(high_profit)::float AS high_profit
+        `;
+      } else if (agg === HistoryAgg.CLOSE) {
+        selectClause = `
+          ${bucketExpr} AS bucket,
+          (ARRAY_AGG(low_profit ORDER BY timestamp DESC))[1]::float AS low_profit,
+          (ARRAY_AGG(high_profit ORDER BY timestamp DESC))[1]::float AS high_profit
+        `;
+      } else {
+        selectClause = `
+          ${bucketExpr} AS bucket,
+          (ARRAY_AGG(low_profit ORDER BY timestamp ASC))[1]::float AS open_low,
+          MAX(low_profit)::float AS high_low,
+          MIN(low_profit)::float AS low_low,
+          (ARRAY_AGG(low_profit ORDER BY timestamp DESC))[1]::float AS close_low,
+          (ARRAY_AGG(high_profit ORDER BY timestamp ASC))[1]::float AS open_high,
+          MAX(high_profit)::float AS high_high,
+          MIN(high_profit)::float AS low_high,
+          (ARRAY_AGG(high_profit ORDER BY timestamp DESC))[1]::float AS close_high
+        `;
+      }
+
+      const sql = `
+        SELECT ${selectClause}
+        FROM variant_history
+        WHERE variant_id = $1 AND timestamp >= $2 AND timestamp <= $3
+        GROUP BY bucket
+        ORDER BY bucket
+      `;
+
+      rows = await this.historyRepo.query(sql, params);
     }
-
-    let selectClause = '';
-    if (agg === HistoryAgg.AVG) {
-      selectClause = `
-        ${bucketExpr} AS bucket,
-        AVG(low_profit)::float AS low_profit,
-        AVG(high_profit)::float AS high_profit
-      `;
-    } else if (agg === HistoryAgg.CLOSE) {
-      selectClause = `
-        ${bucketExpr} AS bucket,
-        (ARRAY_AGG(low_profit ORDER BY timestamp DESC))[1]::float AS low_profit,
-        (ARRAY_AGG(high_profit ORDER BY timestamp DESC))[1]::float AS high_profit
-      `;
-    } else {
-      selectClause = `
-        ${bucketExpr} AS bucket,
-        (ARRAY_AGG(low_profit ORDER BY timestamp ASC))[1]::float AS open_low,
-        MAX(low_profit)::float AS high_low,
-        MIN(low_profit)::float AS low_low,
-        (ARRAY_AGG(low_profit ORDER BY timestamp DESC))[1]::float AS close_low,
-        (ARRAY_AGG(high_profit ORDER BY timestamp ASC))[1]::float AS open_high,
-        MAX(high_profit)::float AS high_high,
-        MIN(high_profit)::float AS low_high,
-        (ARRAY_AGG(high_profit ORDER BY timestamp DESC))[1]::float AS close_high
-      `;
-    }
-
-    const sql = `
-      SELECT ${selectClause}
-      FROM variant_history
-      WHERE variant_id = $1 AND timestamp >= $2 AND timestamp <= $3
-      GROUP BY bucket
-      ORDER BY bucket
-    `;
-
-    const rows: Record<string, unknown>[] = await this.historyRepo.query(sql, params);
 
     let history: unknown[] = [];
     if (agg === HistoryAgg.OHLC) {

--- a/test/utils/create-test-app.ts
+++ b/test/utils/create-test-app.ts
@@ -11,6 +11,7 @@ import { Method } from '../../src/methods/entities/method.entity';
 import { MethodVariant } from '../../src/methods/entities/variant.entity';
 import { VariantIoItem } from '../../src/methods/entities/io-item.entity';
 import { VariantHistory } from '../../src/methods/entities/variant-history.entity';
+import { VariantHistoryDaily } from '../../src/methods/entities/variant-history-daily.entity';
 import { VariantSnapshot } from '../../src/methods/entities/variant-snapshot.entity';
 import { VariantIoItemSnapshot } from '../../src/methods/entities/io-item-snapshot.entity';
 import { User } from '../../src/auth/entities/user.entity';
@@ -69,6 +70,7 @@ export const createTestApp = async (): Promise<TestApp> => {
           MethodVariant,
           VariantIoItem,
           VariantHistory,
+          VariantHistoryDaily,
           VariantSnapshot,
           VariantIoItemSnapshot,
           User,


### PR DESCRIPTION
## Summary
- Add `showUntradeables` to `GET /items/search` and default the endpoint to returning only tradeable items.
- Apply the new search filter in the items service while allowing clients to include untradeables with `showUntradeables=true`.
- Add service and e2e coverage for the default tradeable-only behavior and the opt-in untradeable-inclusive flow.

## How to test
- `npm run lint`
- `npm test`
- `npm run build`

## Notes
- `GET /items/search` now excludes untradeable items unless `showUntradeables=true` is provided.
