### PR TITLE
feat(methods): Add period-over-period trending profit ranking

### DIFF
--- a/sql/2026-07-07-create-variant-history-variant-timestamp-index.sql
+++ b/sql/2026-07-07-create-variant-history-variant-timestamp-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS variant_history_variant_id_timestamp_desc_idx
+ON variant_history (variant_id, "timestamp" DESC);

--- a/src/methods/methods.controller.spec.ts
+++ b/src/methods/methods.controller.spec.ts
@@ -67,3 +67,62 @@ describe('MethodsController skills summary endpoint', () => {
     );
   });
 });
+
+describe('MethodsController trending profit endpoint', () => {
+  it('forwards trending profit query params and authorization header to service', async () => {
+    const svc: { listTrendingProfitResponse: jest.Mock } = {
+      listTrendingProfitResponse: jest.fn().mockResolvedValue({ data: { methods: [] }, meta: {} }),
+    };
+
+    const controller = new MethodsController(svc as unknown as MethodsService);
+    const req = { headers: { authorization: 'Bearer token' } } as unknown as Request;
+
+    await controller.findTrendingProfit(
+      '24h',
+      'reliable',
+      '2',
+      '20',
+      'zezima',
+      'craft',
+      'Skilling',
+      '3',
+      '4',
+      '1',
+      'true',
+      'Magic',
+      'true',
+      'true',
+      'false',
+      'all',
+      '1000',
+      '5',
+      '50000',
+      undefined,
+      req,
+    );
+
+    expect(svc.listTrendingProfitResponse).toHaveBeenCalledWith({
+      window: '24h',
+      mode: 'reliable',
+      page: '2',
+      perPage: '20',
+      username: 'zezima',
+      name: 'craft',
+      category: 'Skilling',
+      clickIntensity: '3',
+      afkiness: '4',
+      riskLevel: '1',
+      givesExperience: 'true',
+      skill: 'Magic',
+      showProfitables: 'true',
+      enabled: 'true',
+      likedByMe: 'false',
+      variants: 'all',
+      minGrowthAbs: '1000',
+      minGrowthPct: '5',
+      minCurrentProfit: '50000',
+      minProfit: undefined,
+      authorization: 'Bearer token',
+    });
+  });
+});

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -234,6 +234,122 @@ export class MethodsController {
     return this.svc.skillsSummaryWithProfitResponse(username, req?.headers.authorization, enabled);
   }
 
+  @Get('trending-profit')
+  @ApiOperation({
+    summary: 'List methods by profit growth',
+    description:
+      'Returns methods ordered by period-over-period median profit growth using low/high profit history.',
+  })
+  @ApiQuery({ name: 'window', required: false, enum: ['15m', '1h', '24h', '7d', '30d'] })
+  @ApiQuery({ name: 'mode', required: false, enum: ['reliable', 'instant', 'slow'] })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number (default 1)' })
+  @ApiQuery({ name: 'perPage', required: false, description: 'Items per page (default 10)' })
+  @ApiQuery({ name: 'name', required: false, description: 'Search methods by name' })
+  @ApiQuery({ name: 'username', required: false, description: 'RuneScape username for context' })
+  @ApiQuery({ name: 'category', required: false, description: 'Filter by a single category' })
+  @ApiQuery({ name: 'skill', required: false, description: 'Filter by skill' })
+  @ApiQuery({ name: 'givesExperience', required: false, description: 'true or false' })
+  @ApiQuery({ name: 'showProfitables', required: false, description: 'true or false' })
+  @ApiQuery({ name: 'enabled', required: false, description: 'true or false (default true)' })
+  @ApiQuery({
+    name: 'likedByMe',
+    required: false,
+    description: 'true to return only methods liked by the authenticated user',
+  })
+  @ApiQuery({
+    name: 'variants',
+    required: false,
+    enum: ['best', 'all'],
+    description:
+      'best (default) returns the top-growth variant per method. all returns one method entry per variant.',
+  })
+  @ApiQuery({
+    name: 'minGrowthAbs',
+    required: false,
+    description: 'Minimum selected absolute profit growth, default 0',
+  })
+  @ApiQuery({
+    name: 'minGrowthPct',
+    required: false,
+    description: 'Minimum selected percent profit growth',
+  })
+  @ApiQuery({
+    name: 'minCurrentProfit',
+    required: false,
+    description: 'Minimum selected current-period median profit, default 0',
+  })
+  @ApiQuery({
+    name: 'minProfit',
+    required: false,
+    description: 'Alias for minCurrentProfit',
+  })
+  @ApiOkResponse({
+    description: 'Methods list ordered by profit growth',
+    schema: {
+      example: {
+        status: 'ok',
+        data: { methods: [METHOD_EXAMPLE], user: null },
+        warnings: [],
+        meta: {
+          total: 1,
+          page: 1,
+          pageSize: 10,
+          perPage: 10,
+          hasNext: false,
+          window: '24h',
+          mode: 'reliable',
+        },
+      },
+    },
+  })
+  async findTrendingProfit(
+    @Query('window') window?: string,
+    @Query('mode') mode?: string,
+    @Query('page') page = '1',
+    @Query('perPage') perPage = '10',
+    @Query('username') username?: string,
+    @Query('name') name?: string,
+    @Query('category') category?: string,
+    @Query('clickIntensity') clickIntensity?: string,
+    @Query('afkiness') afkiness?: string,
+    @Query('riskLevel') riskLevel?: string,
+    @Query('givesExperience') givesExperience?: string,
+    @Query('skill') skill?: string,
+    @Query('showProfitables') showProfitables?: string,
+    @Query('enabled') enabled?: string | boolean,
+    @Query('likedByMe') likedByMe?: string | boolean,
+    @Query('variants') variants?: string,
+    @Query('minGrowthAbs') minGrowthAbs?: string,
+    @Query('minGrowthPct') minGrowthPct?: string,
+    @Query('minCurrentProfit') minCurrentProfit?: string,
+    @Query('minProfit') minProfit?: string,
+    @Req() req?: Request,
+  ) {
+    return this.svc.listTrendingProfitResponse({
+      window,
+      mode,
+      page,
+      perPage,
+      username,
+      name,
+      category,
+      clickIntensity,
+      afkiness,
+      riskLevel,
+      givesExperience,
+      skill,
+      showProfitables,
+      enabled,
+      likedByMe,
+      variants,
+      minGrowthAbs,
+      minGrowthPct,
+      minCurrentProfit,
+      minProfit,
+      authorization: req?.headers.authorization,
+    });
+  }
+
   @Post(':methodId/like')
   @UseGuards(SupabaseAuthGuard)
   @ApiBearerAuth()

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -1066,3 +1066,401 @@ describe('MethodsService variantCount', () => {
     expect(result.data.method.id).toBe('m1');
   });
 });
+
+describe('MethodsService trending profit', () => {
+  const now = new Date('2026-07-07T12:00:00.000Z');
+  const previousTimestamps = [
+    new Date('2026-07-05T13:00:00.000Z'),
+    new Date('2026-07-06T00:00:00.000Z'),
+    new Date('2026-07-06T11:00:00.000Z'),
+  ];
+  const currentTimestamps = [
+    new Date('2026-07-06T13:00:00.000Z'),
+    new Date('2026-07-07T00:00:00.000Z'),
+    new Date('2026-07-07T11:00:00.000Z'),
+  ];
+
+  const buildVariant = (id: string, label = id): MethodVariant =>
+    ({
+      id,
+      slug: id,
+      label,
+      description: null,
+      xpHour: null,
+      clickIntensity: 0,
+      afkiness: 0,
+      riskLevel: '0',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      actionsPerHour: 0,
+      createdAt: new Date(),
+      ioItems: [],
+      method: {} as Method,
+    }) as MethodVariant;
+
+  const buildMethod = (id: string, variants: MethodVariant[]): Method =>
+    ({
+      id,
+      name: `Method ${id}`,
+      slug: `method-${id}`,
+      description: undefined,
+      category: 'Skilling',
+      enabled: true,
+      createdAt: new Date(),
+      variants,
+    }) as Method;
+
+  const createTrendingService = (
+    methods: Method[],
+    historyRows: Array<{
+      variantId: string;
+      timestamp: Date | string;
+      lowProfit: number;
+      highProfit: number;
+    }>,
+  ) => {
+    const methodRepo = {
+      find: jest.fn().mockResolvedValue(methods),
+    } as unknown as Repository<Method>;
+    const historyQuery = jest.fn().mockResolvedValue(historyRows);
+    const historyRepo = {
+      query: historyQuery,
+    } as unknown as Repository<VariantHistory>;
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      historyRepo,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    jest.spyOn(service as any, 'getItemPrices').mockResolvedValue({});
+    jest.spyOn(service as any, 'getItemVolumes24h').mockResolvedValue({});
+
+    return { service, historyQuery };
+  };
+
+  const buildHistoryRows = (
+    variantId: string,
+    previousProfits: number[],
+    currentProfits: number[],
+  ): Array<{ variantId: string; timestamp: Date; lowProfit: number; highProfit: number }> => [
+    ...previousProfits.map((profit, index) => ({
+      variantId,
+      timestamp: previousTimestamps[index],
+      lowProfit: profit,
+      highProfit: profit,
+    })),
+    ...currentProfits.map((profit, index) => ({
+      variantId,
+      timestamp: currentTimestamps[index],
+      lowProfit: profit,
+      highProfit: profit,
+    })),
+  ];
+
+  interface TrendingProfitTestVariant {
+    id: string;
+    profitGrowth: {
+      previousPeriodProfit?: number;
+      currentPeriodProfit?: number;
+      growthAbs?: number;
+      growthPct?: number | null;
+      trendDirection?: 'up' | 'down' | 'flat';
+    };
+  }
+
+  interface TrendingProfitTestMethod {
+    id: string;
+    variants: TrendingProfitTestVariant[];
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(now);
+    call.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('uses period-over-period medians and orders by absolute growth instead of percentage', async () => {
+    const small = buildMethod('small', [buildVariant('v-small')]);
+    const big = buildMethod('big', [buildVariant('v-big')]);
+    const { service } = createTrendingService(
+      [small, big],
+      [
+        ...buildHistoryRows('v-small', [1, 1, 1], [1_000, 1_000, 1_000]),
+        ...buildHistoryRows(
+          'v-big',
+          [1_000_000, 1_000_000, 1_000_000],
+          [1_300_000, 1_300_000, 1_300_000],
+        ),
+      ],
+    );
+
+    const result = await service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'reliable', minGrowthAbs: 0, minCurrentProfit: 0 },
+    );
+    const methods = result.data as TrendingProfitTestMethod[];
+
+    expect(methods.map((method) => method.id)).toEqual(['big', 'small']);
+    expect(methods[0].variants[0].profitGrowth).toMatchObject({
+      previousPeriodProfit: 1_000_000,
+      currentPeriodProfit: 1_300_000,
+      growthAbs: 300_000,
+      growthPct: 30,
+      trendDirection: 'up',
+    });
+    expect(methods[0].variants[0].profitGrowth).not.toHaveProperty('selectedGrowthAbs');
+    expect(methods[0].variants[0].profitGrowth).not.toHaveProperty('sampleCountPrevious');
+    expect(methods[0].variants[0].profitGrowth).not.toHaveProperty('lowGrowthAbs');
+    expect(methods[1].variants[0].profitGrowth.growthPct).toBe(99_900);
+  });
+
+  it('uses median so a previous-period spike does not contaminate the trend', async () => {
+    const method = buildMethod('m1', [buildVariant('v1')]);
+    const { service } = createTrendingService(
+      [method],
+      buildHistoryRows('v1', [100_000, 500_000, 105_000], [150_000, 155_000, 160_000]),
+    );
+
+    const result = await service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'reliable', minGrowthAbs: 0, minCurrentProfit: 0 },
+    );
+    const methods = result.data as TrendingProfitTestMethod[];
+
+    expect(methods[0].variants[0].profitGrowth).toMatchObject({
+      previousPeriodProfit: 105_000,
+      currentPeriodProfit: 155_000,
+      growthAbs: 50_000,
+    });
+    expect(methods[0].variants[0].profitGrowth.growthPct).toBeCloseTo(47.619, 3);
+  });
+
+  it('uses reliable growth as the minimum growth across low and high profit', async () => {
+    const method = buildMethod('m1', [buildVariant('v1'), buildVariant('v2')]);
+    const { service } = createTrendingService(
+      [method],
+      [
+        ...[
+          ...previousTimestamps.map((timestamp) => ({
+            variantId: 'v1',
+            timestamp,
+            lowProfit: 100,
+            highProfit: 100,
+          })),
+          ...currentTimestamps.map((timestamp) => ({
+            variantId: 'v1',
+            timestamp,
+            lowProfit: 300,
+            highProfit: 120,
+          })),
+        ],
+        ...[
+          ...previousTimestamps.map((timestamp) => ({
+            variantId: 'v2',
+            timestamp,
+            lowProfit: 100,
+            highProfit: 100,
+          })),
+          ...currentTimestamps.map((timestamp) => ({
+            variantId: 'v2',
+            timestamp,
+            lowProfit: 180,
+            highProfit: 180,
+          })),
+        ],
+      ],
+    );
+
+    const result = await service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'reliable', minGrowthAbs: 0, minCurrentProfit: 0 },
+    );
+    const methods = result.data as TrendingProfitTestMethod[];
+
+    expect(methods[0].variants[0]).toMatchObject({
+      id: 'v2',
+      profitGrowth: { growthAbs: 80, growthPct: 80 },
+    });
+  });
+
+  it('switches selected growth for instant and slow modes', async () => {
+    const method = buildMethod('m1', [buildVariant('v-instant'), buildVariant('v-slow')]);
+    const baselineRows = [
+      ...previousTimestamps.map((timestamp) => ({
+        variantId: 'v-instant',
+        timestamp,
+        lowProfit: 100,
+        highProfit: 100,
+      })),
+      ...currentTimestamps.map((timestamp) => ({
+        variantId: 'v-instant',
+        timestamp,
+        lowProfit: 300,
+        highProfit: 110,
+      })),
+      ...previousTimestamps.map((timestamp) => ({
+        variantId: 'v-slow',
+        timestamp,
+        lowProfit: 100,
+        highProfit: 100,
+      })),
+      ...currentTimestamps.map((timestamp) => ({
+        variantId: 'v-slow',
+        timestamp,
+        lowProfit: 120,
+        highProfit: 500,
+      })),
+    ];
+
+    const instant = createTrendingService([method], baselineRows);
+
+    const instantResult = await instant.service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'instant', minGrowthAbs: 0, minCurrentProfit: 0 },
+    );
+    const instantMethods = instantResult.data as TrendingProfitTestMethod[];
+
+    expect(instantMethods[0].variants[0]).toMatchObject({
+      id: 'v-instant',
+      profitGrowth: { growthAbs: 200 },
+    });
+
+    jest.restoreAllMocks();
+    const slow = createTrendingService([method], baselineRows);
+
+    const slowResult = await slow.service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'slow', minGrowthAbs: 0, minCurrentProfit: 0 },
+    );
+    const slowMethods = slowResult.data as TrendingProfitTestMethod[];
+
+    expect(slowMethods[0].variants[0]).toMatchObject({
+      id: 'v-slow',
+      profitGrowth: { growthAbs: 400 },
+    });
+  });
+
+  it('excludes variants when previous or current median profit is not positive', async () => {
+    const method = buildMethod('m1', [buildVariant('v1')]);
+    const { service } = createTrendingService(
+      [method],
+      buildHistoryRows('v1', [0, 0, 0], [100, 100, 100]),
+    );
+
+    const result = await service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'reliable', minGrowthAbs: 0, minCurrentProfit: 0 },
+    );
+
+    expect(result.data).toHaveLength(0);
+  });
+
+  it('excludes variants without enough samples in both periods', async () => {
+    const method = buildMethod('m1', [
+      buildVariant('v-good'),
+      buildVariant('v-missing'),
+      buildVariant('v-insufficient'),
+    ]);
+    const { service, historyQuery } = createTrendingService(
+      [method],
+      [
+        ...buildHistoryRows('v-good', [100, 100, 100], [200, 250, 300]),
+        {
+          variantId: 'v-insufficient',
+          timestamp: previousTimestamps[0],
+          lowProfit: 100,
+          highProfit: 100,
+        },
+        {
+          variantId: 'v-insufficient',
+          timestamp: currentTimestamps[0],
+          lowProfit: 200,
+          highProfit: 200,
+        },
+      ],
+    );
+
+    const result = await service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'reliable', minGrowthAbs: 0, minCurrentProfit: 0 },
+      {},
+      'all',
+    );
+
+    expect(result.data).toHaveLength(1);
+    const methods = result.data as TrendingProfitTestMethod[];
+    expect(methods[0].variants[0].id).toBe('v-good');
+    expect(historyQuery).toHaveBeenCalledWith(expect.stringContaining('variant_id IN'), [
+      'v-good',
+      'v-missing',
+      'v-insufficient',
+      '2026-07-05T12:00:00.000Z',
+      '2026-07-07T12:00:00.000Z',
+    ]);
+  });
+
+  it('returns one row per variant when variants mode is all', async () => {
+    const method = buildMethod('m1', [buildVariant('v1'), buildVariant('v2')]);
+    const { service } = createTrendingService(
+      [method],
+      [
+        ...buildHistoryRows('v1', [100, 100, 100], [200, 200, 200]),
+        ...buildHistoryRows('v2', [100, 100, 100], [300, 300, 300]),
+      ],
+    );
+
+    const result = await service.findTrendingProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { window: '24h', mode: 'reliable', minGrowthAbs: 0, minCurrentProfit: 0 },
+      {},
+      'all',
+    );
+
+    expect(result.total).toBe(2);
+    const methods = result.data as TrendingProfitTestMethod[];
+    expect(methods.map((methodRow) => methodRow.variants[0].id)).toEqual(['v2', 'v1']);
+  });
+
+  it('requires authentication for likedByMe trending filter', async () => {
+    const { service } = createTrendingService([], []);
+
+    await expect(service.listTrendingProfitResponse({ likedByMe: 'true' })).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+});

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -77,6 +77,8 @@ interface SortOptions {
 }
 
 type VariantsMode = 'best' | 'all';
+type TrendingProfitWindow = '15m' | '1h' | '24h' | '7d' | '30d';
+type TrendingProfitMode = 'reliable' | 'instant' | 'slow';
 
 interface ListQuery {
   page?: string;
@@ -98,9 +100,86 @@ interface ListQuery {
   authorization?: string;
 }
 
+interface TrendingProfitQuery extends ListQuery {
+  window?: string;
+  mode?: string;
+  minProfit?: string;
+  minGrowthAbs?: string;
+  minGrowthPct?: string;
+  minCurrentProfit?: string;
+}
+
 interface ListLikeOptions {
   likedByUserId?: string;
   onlyLikedByMe?: boolean;
+}
+
+interface TrendingProfitOptions {
+  window: TrendingProfitWindow;
+  mode: TrendingProfitMode;
+  minGrowthAbs: number;
+  minGrowthPct?: number;
+  minCurrentProfit: number;
+}
+
+interface ProfitGrowthPeriodRow {
+  variantId?: string;
+  timestamp?: Date | string;
+  lowProfit?: number | string;
+  highProfit?: number | string;
+}
+
+interface ProfitGrowthPeriodStats {
+  variantId: string;
+  previousLowProfit: number;
+  previousHighProfit: number;
+  currentLowProfit: number;
+  currentHighProfit: number;
+  sampleCountPrevious: number;
+  sampleCountCurrent: number;
+}
+
+interface ProfitGrowthTrendCalculation {
+  previousPeriodProfit: number;
+  currentPeriodProfit: number;
+  growthAbs: number;
+  growthPct: number | null;
+  trendDirection: 'up' | 'down' | 'flat';
+  lowProfit: number;
+  highProfit: number;
+  lowGrowthAbs: number;
+  highGrowthAbs: number;
+  lowGrowthPct: number | null;
+  highGrowthPct: number | null;
+  reliableGrowthAbs: number;
+  reliableGrowthPct: number | null;
+}
+
+interface PublicProfitGrowthMetrics {
+  window: TrendingProfitWindow;
+  mode: TrendingProfitMode;
+  previousPeriodProfit: number;
+  currentPeriodProfit: number;
+  growthAbs: number;
+  growthPct: number | null;
+  trendDirection: 'up' | 'down' | 'flat';
+}
+
+interface ProfitGrowthMetrics extends PublicProfitGrowthMetrics {
+  sampleCountPrevious: number;
+  sampleCountCurrent: number;
+  previousPeriodLowProfit: number;
+  previousPeriodHighProfit: number;
+  currentPeriodLowProfit: number;
+  currentPeriodHighProfit: number;
+  lowGrowthAbs: number;
+  highGrowthAbs: number;
+  reliableGrowthAbs: number;
+  lowGrowthPct: number | null;
+  highGrowthPct: number | null;
+  reliableGrowthPct: number | null;
+  selectedGrowthAbs: number;
+  selectedGrowthPct: number | null;
 }
 
 interface MethodDetailsWithProfit {
@@ -289,6 +368,68 @@ export class MethodsService implements OnModuleDestroy {
     }
 
     throw new BadRequestException('variants must be one of: best, all');
+  }
+
+  private parseTrendingProfitWindow(value: string | undefined): TrendingProfitWindow {
+    if (value == null) return '24h';
+
+    const normalized = value.trim().toLowerCase();
+    if (
+      normalized === '15m' ||
+      normalized === '1h' ||
+      normalized === '24h' ||
+      normalized === '7d' ||
+      normalized === '30d'
+    ) {
+      return normalized;
+    }
+
+    throw new BadRequestException('window must be one of: 15m, 1h, 24h, 7d, 30d');
+  }
+
+  private parseTrendingProfitMode(value: string | undefined): TrendingProfitMode {
+    if (value == null) return 'reliable';
+
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'reliable' || normalized === 'instant' || normalized === 'slow') {
+      return normalized;
+    }
+
+    throw new BadRequestException('mode must be one of: reliable, instant, slow');
+  }
+
+  private parseNonNegativeNumberParam(value: string | undefined, paramName: string): number {
+    if (value == null || value.trim().length === 0) return 0;
+
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      throw new BadRequestException(`${paramName} must be a non-negative number`);
+    }
+
+    return parsed;
+  }
+
+  private parseOptionalNonNegativeNumberParam(
+    value: string | undefined,
+    paramName: string,
+  ): number | undefined {
+    if (value == null || value.trim().length === 0) return undefined;
+    return this.parseNonNegativeNumberParam(value, paramName);
+  }
+
+  private buildTrendingProfitOptions(query: TrendingProfitQuery): TrendingProfitOptions {
+    return {
+      window: this.parseTrendingProfitWindow(query.window),
+      mode: this.parseTrendingProfitMode(query.mode),
+      minGrowthAbs: this.parseNonNegativeNumberParam(query.minGrowthAbs, 'minGrowthAbs'),
+      minGrowthPct: this.parseOptionalNonNegativeNumberParam(query.minGrowthPct, 'minGrowthPct'),
+      minCurrentProfit: this.parseNonNegativeNumberParam(
+        query.minCurrentProfit ?? query.minProfit,
+        query.minCurrentProfit == null && query.minProfit != null
+          ? 'minProfit'
+          : 'minCurrentProfit',
+      ),
+    };
   }
 
   private getExperienceForSkill(xpHour: XpHour | null | undefined, skill: string): number | null {
@@ -553,6 +694,59 @@ export class MethodsService implements OnModuleDestroy {
       pageSize: pp,
       perPage: pp, // Backward-compatible alias for existing clients.
       hasNext,
+      ...(username ? { username } : {}),
+    };
+
+    return {
+      status: warnings.length ? 'partial' : 'ok',
+      data: { methods: result.data, user: userInfo },
+      warnings,
+      meta,
+    };
+  }
+
+  async listTrendingProfitResponse(query: TrendingProfitQuery) {
+    const { page = '1', perPage = '10', username } = query;
+    const p = parseInt(page, 10);
+    const pp = parseInt(perPage, 10);
+    const variantsMode = this.parseVariantsQueryParam(query.variants);
+    const likedByMeFilter = this.parseBooleanQueryParam(query.likedByMe, 'likedByMe');
+    const authenticatedUserId = await this.resolveAuthenticatedUserId(query.authorization);
+
+    if (likedByMeFilter && !authenticatedUserId) {
+      throw new UnauthorizedException('likedByMe filter requires authentication');
+    }
+
+    await this.assertRegisteredUserForUsername(username, query.authorization, authenticatedUserId);
+    const { userInfo, warnings } = await this.fetchUserInfo(username);
+    const filters = this.buildListFilters(query);
+    if (filters.enabled === false) {
+      await this.assertSuperAdminForDisabledMethods(query.authorization);
+    }
+
+    const trendingOptions = this.buildTrendingProfitOptions(query);
+    const result = await this.findTrendingProfit(
+      p,
+      pp,
+      userInfo ?? undefined,
+      filters,
+      trendingOptions,
+      {
+        likedByUserId: authenticatedUserId ?? undefined,
+        onlyLikedByMe: likedByMeFilter === true,
+      },
+      variantsMode,
+    );
+
+    const hasNext = p * pp < result.total;
+    const meta = {
+      total: result.total,
+      page: p,
+      pageSize: pp,
+      perPage: pp,
+      hasNext,
+      window: trendingOptions.window,
+      mode: trendingOptions.mode,
       ...(username ? { username } : {}),
     };
 
@@ -1405,6 +1599,479 @@ export class MethodsService implements OnModuleDestroy {
       pricesByItem,
       volumes24hByItem,
     });
+  }
+
+  private getTrendingWindowMs(window: TrendingProfitWindow): number {
+    const windows: Record<TrendingProfitWindow, number> = {
+      '15m': 15 * 60 * 1000,
+      '1h': 60 * 60 * 1000,
+      '24h': 24 * 60 * 60 * 1000,
+      '7d': 7 * 24 * 60 * 60 * 1000,
+      '30d': 30 * 24 * 60 * 60 * 1000,
+    };
+
+    return windows[window];
+  }
+
+  private getMedian(values: number[]): number | null {
+    if (values.length === 0) return null;
+
+    const sorted = [...values].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 1) return sorted[middle];
+
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+
+  private async getProfitGrowthPeriodStats(
+    variantIds: string[],
+    previousPeriodStart: Date,
+    currentPeriodStart: Date,
+    currentPeriodEnd: Date,
+  ): Promise<Record<string, ProfitGrowthPeriodStats>> {
+    if (variantIds.length === 0) return {};
+
+    const variantPlaceholders = variantIds.map((_, index) => `$${index + 1}`).join(', ');
+    const previousStartParam = variantIds.length + 1;
+    const currentEndParam = variantIds.length + 2;
+    const rawRows = (await this.historyRepo.query(
+      `
+        SELECT
+          variant_id AS "variantId",
+          "timestamp" AS "timestamp",
+          low_profit::float AS "lowProfit",
+          high_profit::float AS "highProfit"
+        FROM variant_history
+        WHERE variant_id IN (${variantPlaceholders})
+          AND "timestamp" >= $${previousStartParam}
+          AND "timestamp" <= $${currentEndParam}
+        ORDER BY variant_id, "timestamp" ASC
+      `,
+      [...variantIds, previousPeriodStart.toISOString(), currentPeriodEnd.toISOString()],
+    )) as unknown;
+    const rows = Array.isArray(rawRows) ? (rawRows as ProfitGrowthPeriodRow[]) : [];
+
+    const grouped: Record<
+      string,
+      {
+        previousLow: number[];
+        previousHigh: number[];
+        currentLow: number[];
+        currentHigh: number[];
+      }
+    > = {};
+
+    for (const row of rows) {
+      if (typeof row.variantId !== 'string' || row.timestamp == null) {
+        continue;
+      }
+
+      const variantId = row.variantId;
+      const timestamp = row.timestamp instanceof Date ? row.timestamp : new Date(row.timestamp);
+      const lowProfit = Number(row.lowProfit);
+      const highProfit = Number(row.highProfit);
+
+      if (
+        variantId.length === 0 ||
+        Number.isNaN(timestamp.getTime()) ||
+        timestamp < previousPeriodStart ||
+        timestamp > currentPeriodEnd ||
+        !Number.isFinite(lowProfit) ||
+        !Number.isFinite(highProfit)
+      ) {
+        continue;
+      }
+
+      const bucket =
+        grouped[variantId] ??
+        (grouped[variantId] = {
+          previousLow: [],
+          previousHigh: [],
+          currentLow: [],
+          currentHigh: [],
+        });
+
+      if (timestamp < currentPeriodStart) {
+        bucket.previousLow.push(lowProfit);
+        bucket.previousHigh.push(highProfit);
+      } else {
+        bucket.currentLow.push(lowProfit);
+        bucket.currentHigh.push(highProfit);
+      }
+    }
+
+    const minSamplesPerPeriod = 2;
+    const stats: Record<string, ProfitGrowthPeriodStats> = {};
+    for (const [variantId, bucket] of Object.entries(grouped)) {
+      if (
+        bucket.previousLow.length < minSamplesPerPeriod ||
+        bucket.currentLow.length < minSamplesPerPeriod
+      ) {
+        continue;
+      }
+
+      const previousLowProfit = this.getMedian(bucket.previousLow);
+      const previousHighProfit = this.getMedian(bucket.previousHigh);
+      const currentLowProfit = this.getMedian(bucket.currentLow);
+      const currentHighProfit = this.getMedian(bucket.currentHigh);
+
+      if (
+        previousLowProfit == null ||
+        previousHighProfit == null ||
+        currentLowProfit == null ||
+        currentHighProfit == null
+      ) {
+        continue;
+      }
+
+      stats[variantId] = {
+        variantId,
+        previousLowProfit,
+        previousHighProfit,
+        currentLowProfit,
+        currentHighProfit,
+        sampleCountPrevious: bucket.previousLow.length,
+        sampleCountCurrent: bucket.currentLow.length,
+      };
+    }
+
+    return stats;
+  }
+
+  private calculateGrowthPct(current: number, previous: number): number | null {
+    if (previous <= 0) return null;
+    return ((current - previous) / previous) * 100;
+  }
+
+  private getTrendDirection(growthAbs: number): 'up' | 'down' | 'flat' {
+    if (growthAbs > 0) return 'up';
+    if (growthAbs < 0) return 'down';
+    return 'flat';
+  }
+
+  private calculatePeriodTrend(
+    stats: ProfitGrowthPeriodStats,
+    mode: TrendingProfitMode,
+  ): ProfitGrowthTrendCalculation {
+    const lowGrowthAbs = stats.currentLowProfit - stats.previousLowProfit;
+    const highGrowthAbs = stats.currentHighProfit - stats.previousHighProfit;
+    const reliableGrowthAbs = Math.min(lowGrowthAbs, highGrowthAbs);
+    const lowGrowthPct = this.calculateGrowthPct(stats.currentLowProfit, stats.previousLowProfit);
+    const highGrowthPct = this.calculateGrowthPct(
+      stats.currentHighProfit,
+      stats.previousHighProfit,
+    );
+    const reliableGrowthPct =
+      lowGrowthPct == null || highGrowthPct == null ? null : Math.min(lowGrowthPct, highGrowthPct);
+
+    if (mode === 'instant') {
+      return {
+        previousPeriodProfit: stats.previousLowProfit,
+        currentPeriodProfit: stats.currentLowProfit,
+        growthAbs: lowGrowthAbs,
+        growthPct: lowGrowthPct,
+        trendDirection: this.getTrendDirection(lowGrowthAbs),
+        lowProfit: stats.currentLowProfit,
+        highProfit: stats.currentHighProfit,
+        lowGrowthAbs,
+        highGrowthAbs,
+        reliableGrowthAbs,
+        lowGrowthPct,
+        highGrowthPct,
+        reliableGrowthPct,
+      };
+    }
+
+    if (mode === 'slow') {
+      return {
+        previousPeriodProfit: stats.previousHighProfit,
+        currentPeriodProfit: stats.currentHighProfit,
+        growthAbs: highGrowthAbs,
+        growthPct: highGrowthPct,
+        trendDirection: this.getTrendDirection(highGrowthAbs),
+        lowProfit: stats.currentLowProfit,
+        highProfit: stats.currentHighProfit,
+        lowGrowthAbs,
+        highGrowthAbs,
+        reliableGrowthAbs,
+        lowGrowthPct,
+        highGrowthPct,
+        reliableGrowthPct,
+      };
+    }
+
+    const previousPeriodProfit = Math.min(stats.previousLowProfit, stats.previousHighProfit);
+    const currentPeriodProfit = Math.min(stats.currentLowProfit, stats.currentHighProfit);
+
+    return {
+      previousPeriodProfit,
+      currentPeriodProfit,
+      growthAbs: reliableGrowthAbs,
+      growthPct: reliableGrowthPct,
+      trendDirection: this.getTrendDirection(reliableGrowthAbs),
+      lowProfit: stats.currentLowProfit,
+      highProfit: stats.currentHighProfit,
+      lowGrowthAbs,
+      highGrowthAbs,
+      reliableGrowthAbs,
+      lowGrowthPct,
+      highGrowthPct,
+      reliableGrowthPct,
+    };
+  }
+
+  private buildProfitGrowthMetrics(
+    stats: ProfitGrowthPeriodStats,
+    options: TrendingProfitOptions,
+  ): ProfitGrowthMetrics {
+    const trend = this.calculatePeriodTrend(stats, options.mode);
+
+    return {
+      window: options.window,
+      mode: options.mode,
+      previousPeriodProfit: trend.previousPeriodProfit,
+      currentPeriodProfit: trend.currentPeriodProfit,
+      growthAbs: trend.growthAbs,
+      growthPct: trend.growthPct,
+      sampleCountPrevious: stats.sampleCountPrevious,
+      sampleCountCurrent: stats.sampleCountCurrent,
+      trendDirection: trend.trendDirection,
+      previousPeriodLowProfit: stats.previousLowProfit,
+      previousPeriodHighProfit: stats.previousHighProfit,
+      currentPeriodLowProfit: stats.currentLowProfit,
+      currentPeriodHighProfit: stats.currentHighProfit,
+      lowGrowthAbs: trend.lowGrowthAbs,
+      highGrowthAbs: trend.highGrowthAbs,
+      reliableGrowthAbs: trend.reliableGrowthAbs,
+      lowGrowthPct: trend.lowGrowthPct,
+      highGrowthPct: trend.highGrowthPct,
+      reliableGrowthPct: trend.reliableGrowthPct,
+      selectedGrowthAbs: trend.growthAbs,
+      selectedGrowthPct: trend.growthPct,
+    };
+  }
+
+  private toPublicProfitGrowthMetrics(metrics: ProfitGrowthMetrics): PublicProfitGrowthMetrics {
+    return {
+      window: metrics.window,
+      mode: metrics.mode,
+      previousPeriodProfit: metrics.previousPeriodProfit,
+      currentPeriodProfit: metrics.currentPeriodProfit,
+      growthAbs: metrics.growthAbs,
+      growthPct: metrics.growthPct,
+      trendDirection: metrics.trendDirection,
+    };
+  }
+
+  async findTrendingProfit(
+    page = 1,
+    perPage = 10,
+    userInfo?: UserInfo,
+    filters: ListFilters = { enabled: true },
+    options: TrendingProfitOptions = {
+      window: '24h',
+      mode: 'reliable',
+      minGrowthAbs: 0,
+      minCurrentProfit: 0,
+    },
+    likeOptions: ListLikeOptions = {},
+    variantsMode: VariantsMode = 'best',
+  ): Promise<{ data: any[]; total: number }> {
+    const allEntities = await this.methodRepo.find({
+      where: { enabled: filters.enabled },
+      relations: ['variants', 'variants.ioItems'],
+    });
+    const variantCounts = allEntities.reduce<Record<string, number>>((acc, method) => {
+      acc[method.id] = method.variants.length;
+      return acc;
+    }, {});
+    let methodsToProcess = allEntities.map((m) => this.toDto(m));
+
+    if (userInfo) {
+      methodsToProcess = filterMethodsByUserStats(methodsToProcess, userInfo);
+    }
+
+    const itemIds = this.collectItemIdsFromMethods(methodsToProcess);
+    const variantIds = methodsToProcess.flatMap((method) =>
+      method.variants.map((variant) => variant.id),
+    );
+    const now = new Date();
+    const windowMs = this.getTrendingWindowMs(options.window);
+    const currentPeriodStart = new Date(now.getTime() - windowMs);
+    const previousPeriodStart = new Date(now.getTime() - windowMs * 2);
+    const [pricesByItem, volumes24hByItem, periodStats] = await Promise.all([
+      this.getItemPrices(itemIds),
+      this.getItemVolumes24h(itemIds),
+      this.getProfitGrowthPeriodStats(variantIds, previousPeriodStart, currentPeriodStart, now),
+    ]);
+    const selectedSkill = filters.skill?.trim().toLowerCase() || undefined;
+
+    let enrichedMethods = methodsToProcess
+      .map((method) => {
+        let enrichedVariants = method.variants.flatMap((variant) => {
+          const stats = periodStats[variant.id];
+          if (!stats) return [];
+
+          const profitGrowthMetrics = this.buildProfitGrowthMetrics(stats, options);
+          if (
+            profitGrowthMetrics.previousPeriodProfit <= 0 ||
+            profitGrowthMetrics.currentPeriodProfit <= 0
+          ) {
+            return [];
+          }
+
+          if (profitGrowthMetrics.currentPeriodProfit <= options.minCurrentProfit) return [];
+          if (profitGrowthMetrics.growthAbs <= options.minGrowthAbs) return [];
+          if (
+            options.minGrowthPct != null &&
+            (profitGrowthMetrics.growthPct == null ||
+              profitGrowthMetrics.growthPct < options.minGrowthPct)
+          ) {
+            return [];
+          }
+
+          const marketImpact = this.calculateVariantMarketImpact(
+            variant,
+            pricesByItem,
+            volumes24hByItem,
+          );
+          const {
+            id,
+            slug,
+            clickIntensity,
+            afkiness,
+            riskLevel,
+            requirements,
+            xpHour,
+            label,
+            description,
+            wilderness,
+          } = variant;
+          const enrichedVariant = {
+            id,
+            slug,
+            xpHour,
+            label,
+            description,
+            clickIntensity,
+            afkiness,
+            riskLevel,
+            requirements,
+            wilderness,
+            lowProfit: profitGrowthMetrics.currentPeriodLowProfit,
+            highProfit: profitGrowthMetrics.currentPeriodHighProfit,
+            marketImpactInstant: marketImpact.marketImpactInstant,
+            marketImpactSlow: marketImpact.marketImpactSlow,
+            profitGrowth: this.toPublicProfitGrowthMetrics(profitGrowthMetrics),
+          };
+
+          if (selectedSkill) {
+            const experienceForSkill = this.getExperienceForSkill(xpHour, selectedSkill);
+            if (experienceForSkill != null) {
+              return [
+                {
+                  ...enrichedVariant,
+                  gpPerXpHigh: profitGrowthMetrics.currentPeriodHighProfit / experienceForSkill,
+                  gpPerXpLow: profitGrowthMetrics.currentPeriodLowProfit / experienceForSkill,
+                },
+              ];
+            }
+          }
+
+          return [enrichedVariant];
+        });
+
+        enrichedVariants = enrichedVariants.filter((v) => {
+          if (
+            filters.clickIntensity != null &&
+            v.clickIntensity != null &&
+            v.clickIntensity > filters.clickIntensity
+          )
+            return false;
+          if (filters.afkiness != null) {
+            if (v.afkiness == null || v.afkiness <= filters.afkiness) return false;
+          }
+          if (
+            filters.riskLevel != null &&
+            v.riskLevel != null &&
+            Number(v.riskLevel) > filters.riskLevel
+          )
+            return false;
+          if (filters.givesExperience != null) {
+            const hasXp = (v.xpHour?.length ?? 0) > 0;
+            if ((filters.givesExperience && !hasXp) || (!filters.givesExperience && hasXp))
+              return false;
+          }
+          if (selectedSkill) {
+            const experienceForSkill = this.getExperienceForSkill(v.xpHour, selectedSkill);
+            if (experienceForSkill == null) return false;
+          }
+          if (filters.showProfitables && v.highProfit <= 0) return false;
+          return true;
+        });
+
+        return { ...method, variants: enrichedVariants };
+      })
+      .filter((m) => {
+        if (filters.name && !m.name.toLowerCase().includes(filters.name.toLowerCase()))
+          return false;
+        if (
+          filters.category &&
+          (!m.category || m.category.toLowerCase() !== filters.category.toLowerCase())
+        )
+          return false;
+        return m.variants.length > 0;
+      });
+
+    const compareGrowthDesc = (
+      a: { profitGrowth?: PublicProfitGrowthMetrics },
+      b: { profitGrowth?: PublicProfitGrowthMetrics },
+    ) => (b.profitGrowth?.growthAbs ?? 0) - (a.profitGrowth?.growthAbs ?? 0);
+
+    if (variantsMode === 'all') {
+      enrichedMethods = enrichedMethods.flatMap((method) => {
+        const variantCount = variantCounts[method.id] ?? 0;
+        const { description: _description, ...methodWithoutDescription } = method;
+        return [...method.variants].sort(compareGrowthDesc).map((variant) => ({
+          ...methodWithoutDescription,
+          variants: [variant],
+          variantCount,
+        }));
+      });
+    } else {
+      enrichedMethods = enrichedMethods.map((method) => {
+        const variantCount = variantCounts[method.id] ?? 0;
+        const bestVariant = [...method.variants].sort(compareGrowthDesc)[0];
+        const { description: _description, ...methodWithoutDescription } = method;
+        return { ...methodWithoutDescription, variants: [bestVariant], variantCount };
+      });
+    }
+
+    const methodIds = enrichedMethods.map((method) => method.id);
+    const likesCountMap = await this.getLikesCountMap(methodIds);
+    const likedMethodIds = likeOptions.likedByUserId
+      ? await this.getLikedMethodIdsByUser(likeOptions.likedByUserId, methodIds)
+      : new Set<string>();
+
+    enrichedMethods = enrichedMethods.map((method) => ({
+      ...method,
+      likes: likesCountMap[method.id] ?? 0,
+      ...(likeOptions.likedByUserId ? { likedByMe: likedMethodIds.has(method.id) } : {}),
+    }));
+
+    if (likeOptions.onlyLikedByMe) {
+      enrichedMethods = enrichedMethods.filter((method) =>
+        likeOptions.likedByUserId ? likedMethodIds.has(method.id) : false,
+      );
+    }
+
+    enrichedMethods.sort((a, b) => compareGrowthDesc(a.variants[0], b.variants[0]));
+
+    const total = enrichedMethods.length;
+    const start = (page - 1) * perPage;
+    const paginated = enrichedMethods.slice(start, start + perPage);
+
+    return { data: paginated, total };
   }
 
   async findAllWithProfit(

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -16,6 +16,7 @@ import { buildMethodFixture } from '../src/testing/fixtures';
 import { Method } from '../src/methods/entities/method.entity';
 import { MethodVariant } from '../src/methods/entities/variant.entity';
 import { VariantIoItem } from '../src/methods/entities/io-item.entity';
+import { VariantHistory } from '../src/methods/entities/variant-history.entity';
 import { createPgMemAdapter } from './utils/pg-mem';
 
 jest.mock('pg', () => createPgMemAdapter());
@@ -47,6 +48,33 @@ describe('Methods (e2e)', () => {
       },
     ],
   });
+
+  const mockRedisProfits = (
+    profits: Record<string, Record<string, { low: number; high: number }>>,
+  ) => {
+    redisCall.mockImplementation((command: string, key: string, field?: string) => {
+      if (command === 'HGETALL' && key === 'methods:profits') {
+        return Promise.resolve(
+          Object.fromEntries(
+            Object.entries(profits).map(([methodId, methodProfits]) => [
+              methodId,
+              JSON.stringify(methodProfits),
+            ]),
+          ),
+        );
+      }
+
+      if (command === 'HGET' && key === 'methods:profits' && field) {
+        return Promise.resolve(JSON.stringify(profits[field] ?? {}));
+      }
+
+      if (command === 'HMGET') {
+        return Promise.resolve([]);
+      }
+
+      return Promise.resolve(null);
+    });
+  };
 
   beforeAll(async () => {
     const testApp = await createTestApp();
@@ -129,16 +157,12 @@ describe('Methods (e2e)', () => {
     );
 
     const variantIds = [savedVariantA.id, savedVariantB.id];
-    const profitPayload = [
-      {
-        [savedMethod.id]: {
-          [variantIds[0]]: { low: 100, high: 200 },
-          [variantIds[1]]: { low: 50, high: 300 },
-        },
+    mockRedisProfits({
+      [savedMethod.id]: {
+        [variantIds[0]]: { low: 100, high: 200 },
+        [variantIds[1]]: { low: 50, high: 300 },
       },
-    ];
-
-    redisCall.mockResolvedValue(JSON.stringify(profitPayload));
+    });
 
     const server = app.getHttpServer() as unknown as Server;
     const res = await request(server).get('/methods').expect(200);
@@ -231,16 +255,12 @@ describe('Methods (e2e)', () => {
     );
 
     const variantIds = [savedVariantA.id, savedVariantB.id];
-    const profitPayload = [
-      {
-        [savedMethod.id]: {
-          [variantIds[0]]: { low: 100, high: 200 },
-          [variantIds[1]]: { low: 50, high: 300 },
-        },
+    mockRedisProfits({
+      [savedMethod.id]: {
+        [variantIds[0]]: { low: 100, high: 200 },
+        [variantIds[1]]: { low: 50, high: 300 },
       },
-    ];
-
-    redisCall.mockResolvedValue(JSON.stringify(profitPayload));
+    });
 
     const server = app.getHttpServer() as unknown as Server;
     const res = await request(server).get('/methods?variants=all').expect(200);
@@ -278,6 +298,141 @@ describe('Methods (e2e)', () => {
       variantCount: 2,
       variants: [{ id: variantIds[0] }],
     });
+  });
+
+  it('GET /methods/trending-profit returns methods ordered by profit growth', async () => {
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+    const historyRepo = dataSource.getRepository(VariantHistory);
+    const seed = buildMethodFixture();
+
+    const smallMethod = await methodRepo.save({
+      name: 'Small mover',
+      slug: 'small-mover',
+      description: seed.description,
+      category: seed.category,
+    });
+    const bigMethod = await methodRepo.save({
+      name: 'Big mover',
+      slug: 'big-mover',
+      description: seed.description,
+      category: seed.category,
+    });
+
+    const smallVariant = await variantRepo.save({
+      label: 'Small variant',
+      slug: 'small-variant',
+      description: null,
+      xpHour: null,
+      clickIntensity: 0,
+      afkiness: 0,
+      riskLevel: '0',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      actionsPerHour: 0,
+      method: smallMethod,
+    });
+    const bigVariant = await variantRepo.save({
+      label: 'Big variant',
+      slug: 'big-variant',
+      description: null,
+      xpHour: null,
+      clickIntensity: 0,
+      afkiness: 0,
+      riskLevel: '0',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      actionsPerHour: 0,
+      method: bigMethod,
+    });
+
+    const hoursAgo = (hours: number) => new Date(Date.now() - hours * 60 * 60 * 1000);
+    await historyRepo.save([
+      ...[47, 36, 25].map((hours) =>
+        historyRepo.create({
+          variant: smallVariant,
+          timestamp: hoursAgo(hours),
+          lowProfit: 1,
+          highProfit: 1,
+        }),
+      ),
+      ...[23, 12, 1].map((hours) =>
+        historyRepo.create({
+          variant: smallVariant,
+          timestamp: hoursAgo(hours),
+          lowProfit: 1_000,
+          highProfit: 1_000,
+        }),
+      ),
+      ...[47, 36, 25].map((hours) =>
+        historyRepo.create({
+          variant: bigVariant,
+          timestamp: hoursAgo(hours),
+          lowProfit: 1_000_000,
+          highProfit: 1_000_000,
+        }),
+      ),
+      ...[23, 12, 1].map((hours) =>
+        historyRepo.create({
+          variant: bigVariant,
+          timestamp: hoursAgo(hours),
+          lowProfit: 1_300_000,
+          highProfit: 1_300_000,
+        }),
+      ),
+    ]);
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .get('/methods/trending-profit?window=24h&mode=reliable&variants=all')
+      .expect(200);
+
+    const body = res.body as {
+      status: string;
+      data: {
+        methods: Array<{
+          id: string;
+          variants: Array<{
+            id: string;
+            profitGrowth: {
+              window: string;
+              mode: string;
+              previousPeriodProfit: number;
+              currentPeriodProfit: number;
+              growthAbs: number;
+              growthPct: number | null;
+              trendDirection: string;
+            };
+          }>;
+        }>;
+      };
+      meta: { total: number; page: number; perPage: number; hasNext: boolean };
+    };
+
+    expect(body.status).toBe('ok');
+    expect(body.meta).toMatchObject({ total: 2, page: 1, perPage: 10, hasNext: false });
+    expect(body.data.methods.map((method) => method.id)).toEqual([bigMethod.id, smallMethod.id]);
+    expect(body.data.methods[0].variants[0]).toMatchObject({
+      id: bigVariant.id,
+      profitGrowth: {
+        window: '24h',
+        mode: 'reliable',
+        previousPeriodProfit: 1_000_000,
+        currentPeriodProfit: 1_300_000,
+        growthAbs: 300_000,
+        growthPct: 30,
+        trendDirection: 'up',
+      },
+    });
+    expect(body.data.methods[0].variants[0].profitGrowth).not.toHaveProperty('selectedGrowthAbs');
+    expect(body.data.methods[0].variants[0].profitGrowth).not.toHaveProperty('sampleCountPrevious');
+    expect(body.data.methods[0].variants[0].profitGrowth).not.toHaveProperty('lowGrowthAbs');
+    expect(body.data.methods[1].variants[0].profitGrowth.growthPct).toBe(99_900);
+
+    await request(server).get('/methods/trending-profit?window=1h').expect(200);
+    await request(server).get('/methods/trending-profit?window=7d').expect(200);
   });
 
   it('GET /methods with skill includes gpPerXpHigh and gpPerXpLow per variant', async () => {
@@ -345,16 +500,12 @@ describe('Methods (e2e)', () => {
     );
 
     const variantIds = [savedVariantA.id, savedVariantB.id];
-    const profitPayload = [
-      {
-        [savedMethod.id]: {
-          [variantIds[0]]: { low: 5000, high: 10000 },
-          [variantIds[1]]: { low: 4000, high: 8000 },
-        },
+    mockRedisProfits({
+      [savedMethod.id]: {
+        [variantIds[0]]: { low: 5000, high: 10000 },
+        [variantIds[1]]: { low: 4000, high: 8000 },
       },
-    ];
-
-    redisCall.mockResolvedValue(JSON.stringify(profitPayload));
+    });
 
     const server = app.getHttpServer() as unknown as Server;
     const res = await request(server).get('/methods?skill=magic&variants=all').expect(200);


### PR DESCRIPTION
## Summary
- Add `showUntradeables` to `GET /items/search` and default the endpoint to returning only tradeable items.
- Apply the new search filter in the items service while allowing clients to include untradeables with `showUntradeables=true`.
- Add service and e2e coverage for the default tradeable-only behavior and the opt-in untradeable-inclusive flow.

## How to test
- `npm run lint`
- `npm test`
- `npm run build`

## Notes
- `GET /items/search` now excludes untradeable items unless `showUntradeables=true` is provided.
