### PR TITLE
feat(methods): add icon_id support to methods and variants

### DIFF
--- a/sql/2026-07-09-add-method-and-variant-icon-id.sql
+++ b/sql/2026-07-09-add-method-and-variant-icon-id.sql
@@ -1,0 +1,35 @@
+ALTER TABLE money_making_methods
+ADD COLUMN IF NOT EXISTS icon_id integer;
+
+ALTER TABLE method_variants
+ADD COLUMN IF NOT EXISTS icon_id integer;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'fk_money_making_methods_icon_id_items'
+  ) THEN
+    ALTER TABLE money_making_methods
+    ADD CONSTRAINT fk_money_making_methods_icon_id_items
+    FOREIGN KEY (icon_id) REFERENCES items (id);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'fk_method_variants_icon_id_items'
+  ) THEN
+    ALTER TABLE method_variants
+    ADD CONSTRAINT fk_method_variants_icon_id_items
+    FOREIGN KEY (icon_id) REFERENCES items (id);
+  END IF;
+END $$;
+
+-- Optional after backfilling existing rows:
+-- ALTER TABLE money_making_methods ALTER COLUMN icon_id SET NOT NULL;
+-- ALTER TABLE method_variants ALTER COLUMN icon_id SET NOT NULL;

--- a/src/methods/dto/create-method.dto.ts
+++ b/src/methods/dto/create-method.dto.ts
@@ -5,6 +5,7 @@ import {
   ValidateNested,
   IsArray,
   IsBoolean,
+  IsInt,
   MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -14,6 +15,7 @@ import { DESCRIPTION_MAX_LENGTH } from './validation.constants';
 
 export class CreateMethodDto {
   @IsString() name: string;
+  @IsInt() icon_id: number;
   @IsOptional()
   @IsString()
   @MaxLength(DESCRIPTION_MAX_LENGTH)

--- a/src/methods/dto/create-variant.dto.ts
+++ b/src/methods/dto/create-variant.dto.ts
@@ -6,6 +6,7 @@ import {
   IsArray,
   ValidateNested,
   IsBoolean,
+  IsInt,
   MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -17,6 +18,7 @@ import { DESCRIPTION_MAX_LENGTH } from './validation.constants';
 
 export class CreateVariantDto {
   @IsString() label: string;
+  @IsInt() icon_id: number;
   @IsOptional() @IsNumber() actionsPerHour?: number;
   @IsOptional()
   @IsArray()

--- a/src/methods/dto/method-response.dto.ts
+++ b/src/methods/dto/method-response.dto.ts
@@ -5,6 +5,7 @@ import { XpHour, VariantRecommendations, VariantRequirements } from '../types';
 export class VariantResponseDto {
   id: string;
   slug: string;
+  icon_id?: number | null;
   label: string;
   description?: string;
   xpHour?: XpHour;
@@ -24,6 +25,7 @@ export class MethodResponseDto {
   id: string;
   name: string;
   slug: string;
+  icon_id?: number | null;
   description?: string;
   category?: string;
   variants: VariantResponseDto[];

--- a/src/methods/dto/method.dto.ts
+++ b/src/methods/dto/method.dto.ts
@@ -3,6 +3,7 @@ import { VariantRequirements, VariantRecommendations, XpHour } from '../types';
 export interface VariantDto {
   id: string;
   slug: string;
+  icon_id?: number | null;
   inputs: { id: number; quantity: number; reason?: string | null }[];
   outputs: { id: number; quantity: number; reason?: string | null }[];
   actionsPerHour?: number;
@@ -22,6 +23,7 @@ export class MethodDto {
   id: string;
   name: string;
   slug: string;
+  icon_id?: number | null;
   description?: string;
   category?: string;
   enabled: boolean;
@@ -31,6 +33,7 @@ export class MethodDto {
     id: string,
     name: string,
     slug: string,
+    icon_id: number | null | undefined,
     description: string,
     category: string,
     enabled: boolean,
@@ -39,6 +42,7 @@ export class MethodDto {
     this.id = id;
     this.name = name;
     this.slug = slug;
+    this.icon_id = icon_id;
     this.description = description;
     this.category = category;
     this.enabled = enabled;
@@ -48,12 +52,14 @@ export class MethodDto {
     id: string;
     name: string;
     slug: string;
+    iconId?: number | null;
     description?: string;
     category?: string;
     enabled: boolean;
     variants: Array<{
       id: string;
       slug: string;
+      iconId?: number | null;
       label: string;
       description: string | null;
       actionsPerHour: number;
@@ -91,6 +97,7 @@ export class MethodDto {
       return {
         id: variant.id,
         slug: variant.slug,
+        icon_id: variant.iconId,
         label: variant.label,
         description: variant.description,
         actionsPerHour: variant.actionsPerHour,
@@ -110,6 +117,7 @@ export class MethodDto {
       e.id,
       e.name,
       e.slug,
+      e.iconId,
       e.description || '',
       e.category || '',
       e.enabled,

--- a/src/methods/dto/update-method.dto.ts
+++ b/src/methods/dto/update-method.dto.ts
@@ -5,6 +5,7 @@ import {
   IsString,
   ValidateNested,
   IsBoolean,
+  IsInt,
   MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -26,6 +27,10 @@ export class UpdateMethodDto {
   @IsOptional()
   @IsString()
   category?: string;
+
+  @IsOptional()
+  @IsInt()
+  icon_id?: number;
 
   @IsOptional()
   @IsBoolean()

--- a/src/methods/dto/update-variant.dto.ts
+++ b/src/methods/dto/update-variant.dto.ts
@@ -6,6 +6,7 @@ import {
   IsArray,
   ValidateNested,
   IsBoolean,
+  IsInt,
   MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -17,6 +18,7 @@ import { DESCRIPTION_MAX_LENGTH } from './validation.constants';
 
 export class UpdateVariantDto {
   @IsOptional() @IsString() label?: string;
+  @IsOptional() @IsInt() icon_id?: number;
   @IsOptional() @IsNumber() actionsPerHour?: number;
   @IsOptional()
   @IsArray()

--- a/src/methods/entities/method.entity.ts
+++ b/src/methods/entities/method.entity.ts
@@ -27,6 +27,9 @@ export class Method {
   @Column({ nullable: true })
   category?: string;
 
+  @Column({ name: 'icon_id', type: 'int', nullable: true })
+  iconId?: number | null;
+
   @Column({ type: 'boolean', default: true })
   enabled: boolean;
 

--- a/src/methods/entities/variant.entity.ts
+++ b/src/methods/entities/variant.entity.ts
@@ -34,6 +34,9 @@ export class MethodVariant {
   @Column({ type: 'text', nullable: true })
   description: string | null;
 
+  @Column({ name: 'icon_id', type: 'int', nullable: true })
+  iconId?: number | null;
+
   // Aquí forzamos que xpHour se guarde/lea de la columna xp_hour
   @Column({
     name: 'xp_hour',

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -39,6 +39,7 @@ const METHOD_EXAMPLE = {
   id: 'm_123',
   name: 'Cooked karambwan',
   slug: 'cooked-karambwan',
+  icon_id: 3145,
   description: 'Cook karambwans for profit.',
   category: 'Cooking',
   enabled: true,
@@ -48,6 +49,7 @@ const METHOD_EXAMPLE = {
     {
       id: 'v_456',
       slug: 'karambwan-basic',
+      icon_id: 3145,
       members: true,
       inputs: [{ id: 3144, quantity: 1, reason: null }],
       outputs: [{ id: 3145, quantity: 1, reason: null }],

--- a/src/methods/methods.module.ts
+++ b/src/methods/methods.module.ts
@@ -12,6 +12,7 @@ import { RuneScapeApiService } from './RuneScapeApiService';
 import { VariantSnapshotModule } from '../variant-snapshots/variant-snapshot.module';
 import { User } from '../auth/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
+import { Item } from '../items/entities/item.entity';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { AuthModule } from '../auth/auth.module';
       VariantHistory,
       MethodLike,
       User,
+      Item,
     ]),
     VariantSnapshotModule,
     AuthModule,

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -29,6 +29,7 @@ import { computeMissingRequirements, filterMethodsByUserStats } from './helpers/
 import { ConfigService } from '@nestjs/config';
 import { User } from '../auth/entities/user.entity';
 import { calculateMarketImpact } from './market-impact-calculator';
+import { Item } from '../items/entities/item.entity';
 
 // Definimos tipos para mayor seguridad
 interface Profit {
@@ -188,6 +189,7 @@ interface MethodDetailsWithProfit {
   id: string;
   name: string;
   slug: string;
+  icon_id?: number | null;
   description?: string;
   category?: string;
   enabled: boolean;
@@ -199,6 +201,7 @@ interface MethodDetailsWithProfit {
 interface SkillSummaryVariant {
   id: string;
   slug: string;
+  icon_id?: number | null;
   xpHour?: XpHour | null;
   label?: string;
   description?: string | null;
@@ -218,6 +221,7 @@ interface SkillSummaryMethod {
   id: string;
   name: string;
   slug: string;
+  icon_id?: number | null;
   category?: string;
   enabled: boolean;
   variants: SkillSummaryVariant[];
@@ -268,6 +272,8 @@ export class MethodsService implements OnModuleDestroy {
     private readonly snapshotSvc: VariantSnapshotService,
     private readonly runescapeApi: RuneScapeApiService,
     private readonly config: ConfigService,
+    @InjectRepository(Item)
+    private readonly itemRepo?: Repository<Item>,
   ) {
     const redisUrl = this.config.get<string>('REDIS_URL') as string;
     this.redis = new IORedis(redisUrl);
@@ -934,6 +940,7 @@ export class MethodsService implements OnModuleDestroy {
           return {
             id: variant.id,
             slug: variant.slug,
+            icon_id: variant.icon_id,
             xpHour: variant.xpHour,
             label: variant.label,
             description: variant.description,
@@ -1113,9 +1120,75 @@ export class MethodsService implements OnModuleDestroy {
     return slug;
   }
 
+  private async assertIconItemIdsExist(iconIds: number[]): Promise<void> {
+    const uniqueIconIds = [...new Set(iconIds.filter((iconId) => Number.isInteger(iconId)))];
+    if (uniqueIconIds.length === 0) return;
+    if (!this.itemRepo) {
+      throw new Error('Item repository is not configured');
+    }
+
+    const existingItems = await this.itemRepo.find({
+      select: { id: true },
+      where: { id: In(uniqueIconIds) },
+    });
+    const existingIds = new Set(existingItems.map((item) => item.id));
+    const missingIds = uniqueIconIds.filter((iconId) => !existingIds.has(iconId));
+
+    if (missingIds.length > 0) {
+      throw new BadRequestException(
+        `icon_id must reference an existing item. Missing ids: ${missingIds.join(', ')}`,
+      );
+    }
+  }
+
+  private async validateCreateIconIds(createDto: CreateMethodDto): Promise<void> {
+    const methodIconId = createDto.icon_id;
+    const variantIconIds = createDto.variants.map((variant, index) => {
+      if (variant.icon_id == null) {
+        throw new BadRequestException(`variants[${index}].icon_id is required`);
+      }
+      return variant.icon_id;
+    });
+
+    await this.assertIconItemIdsExist([methodIconId, ...variantIconIds]);
+  }
+
+  private async validateUpdateIconIds(method: Method, updateDto: UpdateMethodDto): Promise<void> {
+    const iconIds: number[] = [];
+    if (updateDto.icon_id != null) {
+      iconIds.push(updateDto.icon_id);
+    }
+
+    const existingVariants = new Map(method.variants.map((variant) => [variant.id, variant]));
+    for (const [index, variant] of (updateDto.variants ?? []).entries()) {
+      const isExistingVariant = variant.id != null && existingVariants.has(variant.id);
+      if (!isExistingVariant && variant.icon_id == null) {
+        throw new BadRequestException(`variants[${index}].icon_id is required for new variants`);
+      }
+      if (variant.icon_id != null) {
+        iconIds.push(variant.icon_id);
+      }
+    }
+
+    await this.assertIconItemIdsExist(iconIds);
+  }
+
+  private async validateVariantIconId(updateDto: UpdateVariantDto): Promise<void> {
+    if (updateDto.icon_id == null) return;
+    await this.assertIconItemIdsExist([updateDto.icon_id]);
+  }
+
   async create(createDto: CreateMethodDto): Promise<MethodDto> {
-    const { name, description, category, enabled, variants } = createDto;
-    const method = this.methodRepo.create({ name, description, category, enabled });
+    await this.validateCreateIconIds(createDto);
+
+    const { name, description, category, enabled, variants, icon_id } = createDto;
+    const method = this.methodRepo.create({
+      name,
+      description,
+      category,
+      enabled,
+      iconId: icon_id,
+    });
     method.slug = await this.generateMethodSlug(name);
     await this.methodRepo.save(method);
 
@@ -1128,6 +1201,7 @@ export class MethodsService implements OnModuleDestroy {
         clickIntensity: v.clickIntensity,
         afkiness: v.afkiness,
         riskLevel: v.riskLevel,
+        iconId: v.icon_id,
         description: v.description ?? null,
         wilderness: v.wilderness ?? false,
         members: v.members ?? false,
@@ -1190,7 +1264,9 @@ export class MethodsService implements OnModuleDestroy {
       throw new NotFoundException(`Method ${id} not found`);
     }
 
-    const { variants = [], name, description, category, enabled } = updateDto;
+    await this.validateUpdateIconIds(method, updateDto);
+
+    const { variants = [], name, description, category, enabled, icon_id } = updateDto;
 
     if (name !== undefined) {
       method.name = name;
@@ -1198,6 +1274,7 @@ export class MethodsService implements OnModuleDestroy {
     }
     if (description !== undefined) method.description = description;
     if (category !== undefined) method.category = category;
+    if (icon_id !== undefined) method.iconId = icon_id;
     if (enabled !== undefined) method.enabled = enabled;
 
     const existingVariants = new Map(method.variants.map((v) => [v.id, v]));
@@ -1212,9 +1289,13 @@ export class MethodsService implements OnModuleDestroy {
           snapshotName: _snapshotName,
           snapshotDescription: _snapshotDescription,
           snapshotDate: _snapshotDate,
+          icon_id: variantIconId,
           ...rest
         } = v;
         Object.assign(variant, rest);
+        if (variantIconId !== undefined) {
+          variant.iconId = variantIconId;
+        }
 
         if (v.label) {
           variant.slug = await this.generateVariantSlug(method.id, v.label, v.id);
@@ -1254,11 +1335,13 @@ export class MethodsService implements OnModuleDestroy {
           snapshotName: _snapshotName,
           snapshotDescription: _snapshotDescription,
           snapshotDate: _snapshotDate,
+          icon_id: variantIconId,
           ...rest
         } = v;
         const variant = this.variantRepo.create({
           method,
           label,
+          iconId: variantIconId,
           ...rest,
         });
         variant.slug = await this.generateVariantSlug(method.id, label);
@@ -1338,15 +1421,22 @@ export class MethodsService implements OnModuleDestroy {
       relations: ['ioItems', 'method'],
     });
     if (!variant) throw new NotFoundException(`Variant ${id} not found`);
+
+    await this.validateVariantIconId(dto);
+
     const {
       inputs = [],
       outputs = [],
       snapshotName,
       snapshotDescription,
       snapshotDate,
+      icon_id,
       ...rest
     } = dto;
     Object.assign(variant, rest);
+    if (icon_id !== undefined) {
+      variant.iconId = icon_id;
+    }
 
     if (dto.label) {
       variant.slug = await this.generateVariantSlug(variant.method.id, dto.label, id);
@@ -1944,6 +2034,7 @@ export class MethodsService implements OnModuleDestroy {
           const {
             id,
             slug,
+            icon_id,
             clickIntensity,
             afkiness,
             riskLevel,
@@ -1957,6 +2048,7 @@ export class MethodsService implements OnModuleDestroy {
           const enrichedVariant = {
             id,
             slug,
+            icon_id,
             xpHour,
             label,
             description,
@@ -2131,6 +2223,7 @@ export class MethodsService implements OnModuleDestroy {
           const {
             id,
             slug,
+            icon_id,
             clickIntensity,
             afkiness,
             riskLevel,
@@ -2144,6 +2237,7 @@ export class MethodsService implements OnModuleDestroy {
           const enrichedVariant = {
             id,
             slug,
+            icon_id,
             xpHour,
             label,
             description,
@@ -2466,6 +2560,7 @@ export class MethodsService implements OnModuleDestroy {
       id: methodDto.id,
       name: methodDto.name,
       slug: methodDto.slug,
+      icon_id: methodDto.icon_id,
       description: methodDto.description,
       category: methodDto.category,
       enabled: methodDto.enabled,

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -12,7 +12,8 @@ import * as request from 'supertest';
 import { Server } from 'http';
 import { DataSource } from 'typeorm';
 import { createTestApp } from './utils/create-test-app';
-import { buildMethodFixture } from '../src/testing/fixtures';
+import { buildItemFixture, buildMethodFixture } from '../src/testing/fixtures';
+import { Item } from '../src/items/entities/item.entity';
 import { Method } from '../src/methods/entities/method.entity';
 import { MethodVariant } from '../src/methods/entities/variant.entity';
 import { VariantIoItem } from '../src/methods/entities/io-item.entity';
@@ -51,6 +52,19 @@ describe('Methods (e2e)', () => {
     ],
   });
 
+  const seedItems = async (...ids: number[]) => {
+    const itemRepo = dataSource.getRepository(Item);
+    await itemRepo.save(
+      ids.map((id) =>
+        buildItemFixture({
+          id,
+          name: `Item ${id}`,
+          iconPath: `Item_${id}.png`,
+        }),
+      ),
+    );
+  };
+
   const mockRedisProfits = (
     profits: Record<string, Record<string, { low: number; high: number }>>,
   ) => {
@@ -88,6 +102,7 @@ describe('Methods (e2e)', () => {
     await dataSource.query('DELETE FROM "variant_io_items"');
     await dataSource.query('DELETE FROM "method_variants"');
     await dataSource.query('DELETE FROM "money_making_methods"');
+    await dataSource.query('DELETE FROM "items"');
     redisCall.mockReset();
   });
 
@@ -354,6 +369,7 @@ describe('Methods (e2e)', () => {
       },
     });
 
+    const server = app.getHttpServer() as unknown as Server;
     const res = await request(server).get('/methods?members=false&variants=all').expect(200);
 
     const body = res.body as {
@@ -604,7 +620,170 @@ describe('Methods (e2e)', () => {
     });
   });
 
+  it('POST /methods stores icon_id and GET /methods/:id returns it for method and variant', async () => {
+    await seedItems(100, 200, 4151, 4152);
+
+    const server = app.getHttpServer() as unknown as Server;
+    const createRes = await request(server)
+      .post('/methods')
+      .send(buildValidCreateMethodPayload())
+      .expect(201);
+
+    const createdBody = createRes.body as {
+      data: {
+        id: string;
+        icon_id: number;
+        variants: Array<{ id: string; icon_id: number }>;
+      };
+    };
+
+    expect(createdBody.data.icon_id).toBe(4151);
+    expect(createdBody.data.variants[0].icon_id).toBe(4152);
+
+    mockRedisProfits({
+      [createdBody.data.id]: {
+        [createdBody.data.variants[0].id]: { low: 100, high: 200 },
+      },
+    });
+
+    const detailRes = await request(server).get(`/methods/${createdBody.data.id}`).expect(200);
+    const detailBody = detailRes.body as {
+      status: string;
+      data: {
+        method: {
+          id: string;
+          icon_id: number;
+          variants: Array<{ id: string; icon_id: number }>;
+        };
+      };
+    };
+
+    expect(detailBody.status).toBe('ok');
+    expect(detailBody.data.method).toMatchObject({
+      id: createdBody.data.id,
+      icon_id: 4151,
+    });
+    expect(detailBody.data.method.variants[0]).toMatchObject({
+      id: createdBody.data.variants[0].id,
+      icon_id: 4152,
+    });
+  });
+
+  it('POST /methods rejects icon_id values that do not exist in items', async () => {
+    await seedItems(100, 200, 4151);
+
+    const server = app.getHttpServer() as unknown as Server;
+    const payload = buildValidCreateMethodPayload();
+    payload.variants[0].icon_id = 999999;
+
+    const res = await request(server).post('/methods').send(payload).expect(400);
+    const body = res.body as { message?: unknown };
+    expect(String(body.message)).toContain('icon_id must reference an existing item');
+    expect(String(body.message)).toContain('999999');
+  });
+
+  it('PUT /methods/:id rejects icon_id values that do not exist in items', async () => {
+    await seedItems(4151, 4152);
+
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+
+    const savedMethod = await methodRepo.save({
+      name: 'Editable method',
+      slug: 'editable-method',
+      iconId: 4151,
+      description: 'Safe markdown',
+      category: 'Skilling',
+      enabled: true,
+    });
+
+    const savedVariant = await variantRepo.save({
+      label: 'Editable variant',
+      slug: 'editable-variant',
+      iconId: 4152,
+      description: null,
+      xpHour: null,
+      clickIntensity: 1,
+      afkiness: 1,
+      riskLevel: '1',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      actionsPerHour: 100,
+      method: savedMethod,
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .put(`/methods/${savedMethod.id}`)
+      .send({
+        icon_id: 999999,
+        variants: [
+          {
+            id: savedVariant.id,
+            label: 'Editable variant',
+            icon_id: 4152,
+            inputs: [],
+            outputs: [],
+          },
+        ],
+      })
+      .expect(400);
+
+    const body = res.body as { message?: unknown };
+    expect(String(body.message)).toContain('icon_id must reference an existing item');
+    expect(String(body.message)).toContain('999999');
+  });
+
+  it('PUT /methods/variant/:id rejects icon_id values that do not exist in items', async () => {
+    await seedItems(4151, 4152);
+
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+
+    const savedMethod = await methodRepo.save({
+      name: 'Variant edit method',
+      slug: 'variant-edit-method',
+      iconId: 4151,
+      description: 'Safe markdown',
+      category: 'Skilling',
+      enabled: true,
+    });
+
+    const savedVariant = await variantRepo.save({
+      label: 'Variant edit variant',
+      slug: 'variant-edit-variant',
+      iconId: 4152,
+      description: null,
+      xpHour: null,
+      clickIntensity: 1,
+      afkiness: 1,
+      riskLevel: '1',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      actionsPerHour: 100,
+      method: savedMethod,
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .put(`/methods/variant/${savedVariant.id}`)
+      .send({
+        icon_id: 999999,
+        inputs: [],
+        outputs: [],
+      })
+      .expect(400);
+
+    const body = res.body as { message?: unknown };
+    expect(String(body.message)).toContain('icon_id must reference an existing item');
+    expect(String(body.message)).toContain('999999');
+  });
+
   it('POST /methods rejects unsafe script content in method.description', async () => {
+    await seedItems(100, 200, 4151, 4152);
+
     const server = app.getHttpServer() as unknown as Server;
     const payload = buildValidCreateMethodPayload();
     payload.description = '<script>alert(1)</script>';
@@ -614,6 +793,8 @@ describe('Methods (e2e)', () => {
   });
 
   it('POST /methods rejects unsafe event handler content in variant.description', async () => {
+    await seedItems(100, 200, 4151, 4152);
+
     const server = app.getHttpServer() as unknown as Server;
     const payload = buildValidCreateMethodPayload();
     payload.variants[0].description = '<img src=x onerror=alert(1)>';

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -36,12 +36,14 @@ describe('Methods (e2e)', () => {
 
   const buildValidCreateMethodPayload = () => ({
     name: 'Validated method',
+    icon_id: 4151,
     description: 'Texto **markdown** con [link](https://example.com)',
     category: 'Skilling',
     enabled: true,
     variants: [
       {
         label: 'Validated variant',
+        icon_id: 4152,
         description: 'Lista:\n- item 1\n- item 2',
         inputs: [{ id: 100, quantity: 1, type: 'input', reason: 'Reason text' }],
         outputs: [{ id: 200, quantity: 1, type: 'output', reason: 'Reason text' }],


### PR DESCRIPTION
## Summary
- Add `showUntradeables` to `GET /items/search` and default the endpoint to returning only tradeable items.
- Apply the new search filter in the items service while allowing clients to include untradeables with `showUntradeables=true`.
- Add service and e2e coverage for the default tradeable-only behavior and the opt-in untradeable-inclusive flow.

## How to test
- `npm run lint`
- `npm test`
- `npm run build`

## Notes
- `GET /items/search` now excludes untradeable items unless `showUntradeables=true` is provided.
 