### PR TITLE
fix: improve global error handling for request parsing and database failures

### DIFF
--- a/src/common/filters/http-exception.filter.spec.ts
+++ b/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,90 @@
+import { BadRequestException, HttpStatus } from '@nestjs/common';
+import { ArgumentsHost } from '@nestjs/common/interfaces';
+import { QueryFailedError } from 'typeorm';
+import { HttpExceptionFilter } from './http-exception.filter';
+
+describe('HttpExceptionFilter', () => {
+  const createHost = () => {
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const response = { status, json };
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => response,
+      }),
+    } as ArgumentsHost;
+
+    return { host, response };
+  };
+
+  it('returns validation details for HttpException responses', () => {
+    const filter = new HttpExceptionFilter();
+    const { host, response } = createHost();
+
+    filter.catch(
+      new BadRequestException(['name must be a string', 'variants should not be empty']),
+      host,
+    );
+
+    expect(response.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(response.json).toHaveBeenCalledWith({
+      status: 'error',
+      error: {
+        code: HttpStatus.BAD_REQUEST,
+        message: 'name must be a string; variants should not be empty',
+        details: ['name must be a string', 'variants should not be empty'],
+      },
+    });
+  });
+
+  it('translates oversized body parser errors into 413 responses', () => {
+    const filter = new HttpExceptionFilter();
+    const { host, response } = createHost();
+
+    filter.catch(
+      {
+        type: 'entity.too.large',
+        status: HttpStatus.PAYLOAD_TOO_LARGE,
+        length: 114866,
+        limit: 102400,
+      },
+      host,
+    );
+
+    expect(response.status).toHaveBeenCalledWith(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(response.json).toHaveBeenCalledWith({
+      status: 'error',
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+        message: 'Request body too large. Received 114866 bytes, limit is 102400 bytes.',
+        details: {
+          receivedBytes: 114866,
+          limitBytes: 102400,
+        },
+      },
+    });
+  });
+
+  it('translates query failures into user-facing database errors', () => {
+    const filter = new HttpExceptionFilter();
+    const { host, response } = createHost();
+    const driverError = Object.assign(new Error('insert failed'), {
+      code: '23503',
+      detail: 'Key (item_id)=(999999) is not present in table "items".',
+      constraint: 'variant_io_items_item_id_fkey',
+    });
+    const error = new QueryFailedError('insert into variant_io_items ...', [], driverError);
+
+    filter.catch(error, host);
+
+    expect(response.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(response.json).toHaveBeenCalledWith({
+      status: 'error',
+      error: {
+        code: 'FOREIGN_KEY_VIOLATION',
+        message: 'Key (item_id)=(999999) is not present in table "items".',
+        details: undefined,
+      },
+    });
+  });
+});

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,27 +1,63 @@
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common';
 import { Response } from 'express';
+import { QueryFailedError } from 'typeorm';
+
+interface ParsedException {
+  status: number;
+  code: number | string;
+  message: string;
+  details?: unknown;
+}
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
+    const parsed = this.parseException(exception);
 
-    const isHttpException = exception instanceof HttpException;
-    const status = isHttpException ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
-
-    const rawResponse = isHttpException ? exception.getResponse() : null;
-    const message = this.extractMessage(rawResponse) ?? 'Internal server error';
-    const details = this.extractDetails(rawResponse);
-
-    response.status(status).json({
+    response.status(parsed.status).json({
       status: 'error',
       error: {
-        code: isHttpException ? status : 'UNEXPECTED_ERROR',
-        message,
-        details,
+        code: parsed.code,
+        message: parsed.message,
+        details: parsed.details,
       },
     });
+  }
+
+  private parseException(exception: unknown): ParsedException {
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const rawResponse = exception.getResponse();
+      return {
+        status,
+        code: status,
+        message: this.extractMessage(rawResponse) ?? 'Internal server error',
+        details: this.extractDetails(rawResponse),
+      };
+    }
+
+    const payloadTooLarge = this.parsePayloadTooLargeException(exception);
+    if (payloadTooLarge) {
+      return payloadTooLarge;
+    }
+
+    const invalidJson = this.parseInvalidJsonException(exception);
+    if (invalidJson) {
+      return invalidJson;
+    }
+
+    const queryFailed = this.parseQueryFailedException(exception);
+    if (queryFailed) {
+      return queryFailed;
+    }
+
+    return {
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      code: 'UNEXPECTED_ERROR',
+      message: 'Internal server error',
+    };
   }
 
   private extractMessage(rawResponse: unknown): string | undefined {
@@ -40,5 +76,126 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const value = (rawResponse as { message?: unknown }).message;
     if (Array.isArray(value)) return value;
     return undefined;
+  }
+
+  private parsePayloadTooLargeException(exception: unknown): ParsedException | null {
+    if (!this.isRecord(exception)) return null;
+
+    const type = typeof exception.type === 'string' ? exception.type : undefined;
+    const status =
+      this.toFiniteNumber(exception.status) ?? this.toFiniteNumber(exception.statusCode);
+    if (type !== 'entity.too.large' && status !== HttpStatus.PAYLOAD_TOO_LARGE) {
+      return null;
+    }
+
+    const limit = this.toFiniteNumber(exception.limit);
+    const length = this.toFiniteNumber(exception.length);
+    const details =
+      limit != null || length != null
+        ? {
+            ...(length != null ? { receivedBytes: length } : {}),
+            ...(limit != null ? { limitBytes: limit } : {}),
+          }
+        : undefined;
+
+    let message = 'Request body too large.';
+    if (length != null && limit != null) {
+      message = `Request body too large. Received ${length} bytes, limit is ${limit} bytes.`;
+    } else if (limit != null) {
+      message = `Request body too large. Limit is ${limit} bytes.`;
+    }
+
+    return {
+      status: HttpStatus.PAYLOAD_TOO_LARGE,
+      code: 'PAYLOAD_TOO_LARGE',
+      message,
+      details,
+    };
+  }
+
+  private parseInvalidJsonException(exception: unknown): ParsedException | null {
+    if (!this.isRecord(exception)) return null;
+
+    const type = typeof exception.type === 'string' ? exception.type : undefined;
+    const status =
+      this.toFiniteNumber(exception.status) ?? this.toFiniteNumber(exception.statusCode);
+    if (type !== 'entity.parse.failed' && status !== HttpStatus.BAD_REQUEST) {
+      return null;
+    }
+
+    if (!(exception instanceof SyntaxError) && type !== 'entity.parse.failed') {
+      return null;
+    }
+
+    return {
+      status: HttpStatus.BAD_REQUEST,
+      code: 'INVALID_JSON',
+      message: 'Malformed JSON request body',
+    };
+  }
+
+  private parseQueryFailedException(exception: unknown): ParsedException | null {
+    if (!(exception instanceof QueryFailedError)) return null;
+
+    const driverError = this.isRecord(exception.driverError) ? exception.driverError : {};
+    const postgresCode = typeof driverError.code === 'string' ? driverError.code : undefined;
+    const detail = typeof driverError.detail === 'string' ? driverError.detail : undefined;
+    const constraint =
+      typeof driverError.constraint === 'string' ? driverError.constraint : undefined;
+    const column = typeof driverError.column === 'string' ? driverError.column : undefined;
+
+    switch (postgresCode) {
+      case '22001':
+        return {
+          status: HttpStatus.BAD_REQUEST,
+          code: 'VALUE_TOO_LONG',
+          message:
+            detail ??
+            (column
+              ? `Value too long for column "${column}".`
+              : 'One of the provided values is too long.'),
+        };
+      case '22P02':
+        return {
+          status: HttpStatus.BAD_REQUEST,
+          code: 'INVALID_VALUE',
+          message: detail ?? 'One of the provided values has an invalid format.',
+        };
+      case '23503':
+        return {
+          status: HttpStatus.BAD_REQUEST,
+          code: 'FOREIGN_KEY_VIOLATION',
+          message:
+            detail ??
+            (constraint
+              ? `Referenced record does not exist for constraint "${constraint}".`
+              : 'Referenced record does not exist.'),
+        };
+      case '23505':
+        return {
+          status: HttpStatus.CONFLICT,
+          code: 'UNIQUE_VIOLATION',
+          message:
+            detail ??
+            (constraint
+              ? `Duplicate value violates constraint "${constraint}".`
+              : 'Duplicate value violates a unique constraint.'),
+        };
+      default:
+        return {
+          status: HttpStatus.BAD_REQUEST,
+          code: 'QUERY_FAILED',
+          message: detail ?? exception.message,
+        };
+    }
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+
+  private toFiniteNumber(value: unknown): number | undefined {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+    return value;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ItemsSeederService } from './items/items-seeder.service';
@@ -11,8 +12,11 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { RequestLoggingInterceptor } from './common/interceptors/request-logging.interceptor';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    bodyParser: false,
+  });
   const config = app.get(ConfigService);
+  const requestBodyLimit = config.get<string>('REQUEST_BODY_LIMIT') ?? '1mb';
 
   const nodeEnv = (config.get<string>('NODE_ENV') ?? 'development').toLowerCase();
   const corsOriginsRaw = config.get<string>('CORS_ORIGINS') ?? '';
@@ -31,6 +35,8 @@ async function bootstrap() {
     });
   }
   app.use(helmet());
+  app.useBodyParser('json', { limit: requestBodyLimit });
+  app.useBodyParser('urlencoded', { extended: true, limit: requestBodyLimit });
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
## Summary

- Configure the Nest bootstrap to use explicit JSON and URL-encoded body parser limits via `REQUEST_BODY_LIMIT`
- Normalize global error responses for oversized request bodies, malformed JSON payloads, and TypeORM query failures
- Add unit coverage for validation errors, payload-too-large responses, and translated database constraint failures

## How to test

```powershell
npm run lint
$env:CI='true'; npm test
npm run build
```

## Notes

- `REQUEST_BODY_LIMIT` defaults to `1mb` when the environment variable is not set
- Error payloads are standardized; no successful-path business logic changes were introduced
