### PR TITLE
feat(admin): expose recent catalog entries in overview

### DIFF
--- a/sql/2026-07-14-add-items-created-at.sql
+++ b/sql/2026-07-14-add-items-created-at.sql
@@ -1,0 +1,15 @@
+ALTER TABLE items
+ADD COLUMN IF NOT EXISTS created_at timestamptz;
+
+UPDATE items
+SET created_at = COALESCE(created_at, last_synced_at, now())
+WHERE created_at IS NULL;
+
+ALTER TABLE items
+ALTER COLUMN created_at SET DEFAULT now();
+
+ALTER TABLE items
+ALTER COLUMN created_at SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_items_created_at_desc
+  ON items (created_at DESC, id DESC);

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -36,7 +36,8 @@ export class AdminController {
   @Get('overview')
   @ApiOperation({
     summary: 'Get admin overview',
-    description: 'Returns aggregate site metrics and latest admin script executions.',
+    description:
+      'Returns aggregate site metrics, latest admin script executions, and recently added catalog entries.',
   })
   @ApiOkResponse({
     description: 'Admin overview',
@@ -55,6 +56,23 @@ export class AdminController {
             ],
           },
           latestExecutions: [],
+          latestCatalog: {
+            items: [
+              {
+                id: 4151,
+                name: 'Abyssal whip',
+                iconUrl: 'https://oldschool.runescape.wiki/images/Abyssal_whip.png',
+                addedAt: '2026-07-14T18:09:09.834Z',
+              },
+            ],
+            quests: [
+              {
+                name: "Cook's Assistant",
+                slug: 'cooks-assistant',
+                addedAt: '2026-02-11T21:32:13.214Z',
+              },
+            ],
+          },
         },
       },
     },

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import type { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import { User } from '../auth/entities/user.entity';
 import { Item } from '../items/entities/item.entity';
 import type { ItemsMappingSyncService } from '../items/items-mapping-sync.service';
@@ -23,7 +24,29 @@ describe('AdminService', () => {
       ),
       find: jest.fn().mockResolvedValue([]),
     };
-    const countRepo = { count: jest.fn().mockResolvedValue(0) };
+    const userRepo = { count: jest.fn().mockResolvedValue(0) };
+    const itemRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      query: jest.fn().mockResolvedValue([
+        {
+          id: 4151,
+          name: 'Abyssal whip',
+          icon_path: 'Abyssal whip.png',
+          created_at: '2026-07-14T18:09:09.834Z',
+        },
+      ]),
+    };
+    const questRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      query: jest.fn().mockResolvedValue([
+        {
+          name: "Cook's Assistant",
+          slug: 'cooks-assistant',
+          created_at: '2026-02-11T21:32:13.214Z',
+        },
+      ]),
+    };
+    const methodRepo = { count: jest.fn().mockResolvedValue(0) };
     const variantRepo = {
       query: jest.fn((sql: string) => {
         if (sql.includes('GROUP BY method.enabled')) {
@@ -55,24 +78,37 @@ describe('AdminService', () => {
       }),
     };
     const profitRefresher = { refresh: jest.fn().mockResolvedValue(undefined) };
+    const config = {
+      get: jest.fn((key: string) =>
+        key === 'CDN_BASE' ? 'https://oldschool.runescape.wiki/images/' : undefined,
+      ),
+    };
 
     const service = new AdminService(
       executionRepo as unknown as Repository<AdminScriptExecution>,
-      countRepo as unknown as Repository<User>,
-      countRepo as unknown as Repository<Item>,
-      countRepo as unknown as Repository<Quest>,
-      countRepo as unknown as Repository<Method>,
+      userRepo as unknown as Repository<User>,
+      itemRepo as unknown as Repository<Item>,
+      questRepo as unknown as Repository<Quest>,
+      methodRepo as unknown as Repository<Method>,
       variantRepo as unknown as Repository<MethodVariant>,
       mappingSync as unknown as ItemsMappingSyncService,
       wikiSync as unknown as ItemsWikiSyncService,
       profitRefresher as unknown as MethodProfitRefresherService,
+      config as unknown as ConfigService,
     );
 
-    return { service, executionRepo, mappingSync, variantRepo };
+    return {
+      service,
+      executionRepo,
+      mappingSync,
+      variantRepo,
+      itemRepo,
+      questRepo,
+    };
   }
 
   it('returns total variants for enabled methods grouped by any xpHour skill on the method', async () => {
-    const { service, variantRepo } = createService();
+    const { service, variantRepo, itemRepo, questRepo } = createService();
 
     const response = await service.getOverview();
 
@@ -93,6 +129,25 @@ describe('AdminService', () => {
       { skill: 'Cooking', variants: 2 },
       { skill: 'Magic', variants: 1 },
     ]);
+    expect(itemRepo.query).toHaveBeenCalledWith(expect.stringContaining('FROM items'));
+    expect(questRepo.query).toHaveBeenCalledWith(expect.stringContaining('FROM quests'));
+    expect(response.data.latestCatalog).toEqual({
+      items: [
+        {
+          id: 4151,
+          name: 'Abyssal whip',
+          iconUrl: 'https://oldschool.runescape.wiki/images/Abyssal_whip.png',
+          addedAt: '2026-07-14T18:09:09.834Z',
+        },
+      ],
+      quests: [
+        {
+          name: "Cook's Assistant",
+          slug: 'cooks-assistant',
+          addedAt: '2026-02-11T21:32:13.214Z',
+        },
+      ],
+    });
   });
 
   it('records a successful mapping item sync execution', async () => {

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../auth/entities/user.entity';
@@ -16,6 +17,8 @@ type ScriptResult = Record<string, unknown>;
 
 @Injectable()
 export class AdminService {
+  private cdnBase?: string;
+
   constructor(
     @InjectRepository(AdminScriptExecution)
     private readonly executionRepo: Repository<AdminScriptExecution>,
@@ -32,6 +35,7 @@ export class AdminService {
     private readonly itemsMappingSyncService: ItemsMappingSyncService,
     private readonly itemsWikiSyncService: ItemsWikiSyncService,
     private readonly methodProfitRefresherService: MethodProfitRefresherService,
+    private readonly config: ConfigService,
   ) {}
 
   async getOverview() {
@@ -45,6 +49,8 @@ export class AdminService {
       variants,
       enabledMethodVariantsBySkill,
       latestExecutions,
+      latestItems,
+      latestQuests,
     ] = await Promise.all([
       this.userRepo.count(),
       this.itemRepo.count(),
@@ -55,6 +61,8 @@ export class AdminService {
       this.getMethodVariantCounts(),
       this.getEnabledMethodVariantsBySkill(),
       this.getLatestExecutionsByScript(),
+      this.getLatestItems(),
+      this.getLatestQuests(),
     ]);
 
     return {
@@ -72,6 +80,10 @@ export class AdminService {
           enabledMethodVariantsBySkill,
         },
         latestExecutions,
+        latestCatalog: {
+          items: latestItems,
+          quests: latestQuests,
+        },
       },
     };
   }
@@ -223,6 +235,65 @@ export class AdminService {
     }
 
     return latest;
+  }
+
+  private buildItemIconUrl(iconPath: string): string {
+    if (!this.cdnBase) {
+      const base = (
+        this.config.get<string>('CDN_BASE') ?? 'https://oldschool.runescape.wiki/images/'
+      ).replace(/\/+$/, '');
+      this.cdnBase = base;
+    }
+
+    const path = iconPath
+      .replace(/^\/+/, '')
+      .replace(/ /g, '_')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/'/g, '%27');
+
+    return `${this.cdnBase}/${path}`;
+  }
+
+  private async getLatestItems(): Promise<
+    Array<{ id: number; name: string; iconUrl: string; addedAt: string }>
+  > {
+    const rows = await this.itemRepo.query<
+      Array<{ id: number; name: string; icon_path: string; created_at: string | Date }>
+    >(
+      `
+        SELECT id, name, icon_path, created_at
+        FROM items
+        ORDER BY created_at DESC, id DESC
+        LIMIT 100
+      `,
+    );
+
+    return rows.map((row) => ({
+      id: Number(row.id),
+      name: row.name,
+      iconUrl: this.buildItemIconUrl(row.icon_path),
+      addedAt: new Date(row.created_at).toISOString(),
+    }));
+  }
+
+  private async getLatestQuests(): Promise<Array<{ name: string; slug: string; addedAt: string }>> {
+    const rows = await this.questRepo.query<
+      Array<{ name: string; slug: string; created_at: string | Date }>
+    >(
+      `
+        SELECT name, slug, created_at
+        FROM quests
+        ORDER BY created_at DESC, name ASC
+        LIMIT 5
+      `,
+    );
+
+    return rows.map((row) => ({
+      name: row.name,
+      slug: row.slug,
+      addedAt: new Date(row.created_at).toISOString(),
+    }));
   }
 
   private async runScript(

--- a/src/catalogs/entities/quest.entity.ts
+++ b/src/catalogs/entities/quest.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('quests')
 export class Quest {
@@ -10,4 +10,7 @@ export class Quest {
 
   @Column({ type: 'text' })
   slug: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
 }

--- a/src/items/entities/item.entity.ts
+++ b/src/items/entities/item.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('items')
 export class Item {
@@ -49,4 +49,7 @@ export class Item {
 
   @Column({ name: 'last_synced_at', type: 'timestamptz', default: () => 'now()' })
   lastSyncedAt: Date;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
 }

--- a/src/items/items-wiki-sync.service.ts
+++ b/src/items/items-wiki-sync.service.ts
@@ -211,7 +211,7 @@ export class ItemsWikiSyncService {
         }
 
         try {
-          await this.repo.insert(this.toPersistencePayload(scrapedItem));
+          await this.repo.insert(this.toPersistencePayload(scrapedItem, new Date()));
           summary.totalInserted += 1;
         } catch (error) {
           summary.totalFailed += 1;
@@ -239,7 +239,7 @@ export class ItemsWikiSyncService {
       }
 
       try {
-        const updatePayload = this.toPersistencePayload(scrapedItem);
+        const updatePayload = this.toPersistencePayload(scrapedItem, new Date());
         delete updatePayload.id;
         await this.repo.update({ id: scrapedItem.id }, updatePayload);
         summary.totalUpdated += 1;
@@ -337,7 +337,7 @@ export class ItemsWikiSyncService {
     return Number.isFinite(parsed) ? parsed : null;
   }
 
-  private toPersistencePayload(scrapedItem: ScrapedWikiItemRecord): Partial<Item> {
+  private toPersistencePayload(scrapedItem: ScrapedWikiItemRecord, syncedAt: Date): Partial<Item> {
     return {
       id: scrapedItem.id,
       name: scrapedItem.name,
@@ -354,7 +354,7 @@ export class ItemsWikiSyncService {
       weight: scrapedItem.weight,
       tradeable: scrapedItem.tradeable,
       members: scrapedItem.members,
-      lastSyncedAt: new Date(),
+      lastSyncedAt: syncedAt,
     };
   }
 

--- a/src/testing/fixtures.ts
+++ b/src/testing/fixtures.ts
@@ -21,6 +21,7 @@ export const buildItemFixture = (overrides: Partial<Item> = {}): Item => {
     tradeable: true,
     members: true,
     lastSyncedAt: new Date('2026-01-31T19:30:00.000Z'),
+    createdAt: new Date('2026-01-31T19:30:00.000Z'),
   };
   return { ...base, ...overrides };
 };


### PR DESCRIPTION
## Summary

- Add an `items.created_at` migration and map the new timestamp in the item entity and shared test fixture.
- Preserve a single sync timestamp while inserting or updating wiki-synced items so `created_at` backfills cleanly from existing item data.
- Extend the admin overview payload with recently added items and quests, including CDN-backed item icon URLs.
- Cover the new admin overview catalog data in the service tests and update the controller response documentation.

## How to test

- Apply `sql/2026-07-14-add-items-created-at.sql`
- `npm run lint`
- `CI=true npm test`
- `npm run build`

## Notes

- This PR assumes `quests.created_at` already exists in the database schema and now exposes it through the TypeORM entity for admin overview queries.
