### PR TITLE
feat(methods): add auto-calculated variant tags

### DIFF
--- a/src/methods/dto/method-response.dto.ts
+++ b/src/methods/dto/method-response.dto.ts
@@ -5,6 +5,7 @@ import { XpHour, VariantRecommendations, VariantRequirements } from '../types';
 export class VariantTagResponseDto {
   label: string;
   description: string;
+  severity: 1 | 2 | 3;
 }
 
 export class VariantResponseDto {

--- a/src/methods/dto/method-response.dto.ts
+++ b/src/methods/dto/method-response.dto.ts
@@ -2,6 +2,11 @@
 import { IoItemDto } from './io-item.dto';
 import { XpHour, VariantRecommendations, VariantRequirements } from '../types';
 
+export class VariantTagResponseDto {
+  label: string;
+  description: string;
+}
+
 export class VariantResponseDto {
   id: string;
   slug: string;
@@ -23,6 +28,7 @@ export class VariantResponseDto {
   outputMarketImpactSlow?: number;
   marketImpactInstant?: number;
   marketImpactSlow?: number;
+  tags?: VariantTagResponseDto[];
   inputs: IoItemDto[];
   outputs: IoItemDto[];
 }

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -63,6 +63,13 @@ const METHOD_EXAMPLE = {
       outputMarketImpactSlow: 0.38,
       marketImpactInstant: 0.32,
       marketImpactSlow: 0.21,
+      tags: [
+        {
+          label: 'Safe',
+          description:
+            'This method has stayed above break-even over the last 24 hours. Neither low profit nor high profit dropped below 0 GP.',
+        },
+      ],
       xpHour: [{ skill: 'Cooking', experience: 300000 }],
       wilderness: false,
     },

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -68,6 +68,7 @@ const METHOD_EXAMPLE = {
           label: 'Safe',
           description:
             'This method has stayed above break-even over the last 24 hours. Neither low profit nor high profit dropped below 0 GP.',
+          severity: 1,
         },
       ],
       xpHour: [{ skill: 'Cooking', experience: 300000 }],

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -7,10 +7,11 @@ import { VariantHistory } from './entities/variant-history.entity';
 import { MethodLike } from './entities/method-like.entity';
 import { VariantSnapshotService } from '../variant-snapshots/variant-snapshot.service';
 import { RuneScapeApiService } from './RuneScapeApiService';
-import { buildMethodFixture } from '../testing/fixtures';
+import { buildItemFixture, buildMethodFixture } from '../testing/fixtures';
 import type { ConfigService } from '@nestjs/config';
 import { User } from '../auth/entities/user.entity';
 import { BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { Item } from '../items/entities/item.entity';
 
 type MethodDetailsWithProfitResult = Awaited<
   ReturnType<MethodsService['findMethodDetailsWithProfit']>
@@ -1149,6 +1150,184 @@ describe('MethodsService variantCount', () => {
       perPage: 1,
       hasNext: true,
     });
+  });
+
+  it('includes auto-calculated tags on list variants', async () => {
+    const methodEntity = buildMethodFixture();
+    methodEntity.id = 'm1';
+    methodEntity.variants = [methodEntity.variants[0]];
+    methodEntity.variants[0].id = 'v1';
+    methodEntity.variants[0].ioItems = [
+      Object.assign(new VariantIoItem(), {
+        id: 1,
+        itemId: 100,
+        quantity: 1200,
+        type: 'input',
+        reason: null,
+        createdAt: new Date(),
+        variant: methodEntity.variants[0],
+      }),
+      Object.assign(new VariantIoItem(), {
+        id: 2,
+        itemId: 200,
+        quantity: 1500,
+        type: 'output',
+        reason: null,
+        createdAt: new Date(),
+        variant: methodEntity.variants[0],
+      }),
+    ];
+
+    const methodRepo = {
+      find: jest.fn().mockResolvedValue([methodEntity]),
+    } as unknown as Repository<Method>;
+
+    const historyRepo = {
+      query: jest.fn().mockResolvedValue([
+        {
+          variantId: 'v1',
+          minLowProfit: 100,
+          minHighProfit: 200,
+          sampleCount: 12,
+        },
+      ]),
+    } as unknown as Repository<VariantHistory>;
+
+    const itemRepo = {
+      find: jest
+        .fn()
+        .mockResolvedValue([
+          buildItemFixture({ id: 100, name: 'Coal', buyLimit: 4000 }),
+          buildItemFixture({ id: 200, name: 'Rune bar', buyLimit: 10000 }),
+        ]),
+    } as unknown as Repository<Item>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      historyRepo,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+      itemRepo,
+    );
+
+    jest.spyOn(service as any, 'getAllMethodsProfits').mockResolvedValue({
+      m1: {
+        v1: { low: 8_100_000, high: 10_800_000 },
+      },
+    });
+    jest.spyOn(service as any, 'getItemPrices').mockResolvedValue({
+      100: { high: 12_000, low: 11_000 },
+      200: { high: 16_000, low: 15_000 },
+    });
+    jest.spyOn(service as any, 'getItemVolumes24h').mockResolvedValue({
+      100: { high24h: 960, low24h: 960 },
+      200: { high24h: 960, low24h: 960 },
+    });
+
+    const result = (await service.findAllWithProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true },
+      { sortBy: 'highProfit', order: 'desc' },
+    )) as {
+      data: Array<{
+        variants: Array<{
+          tags: Array<{ label: string; description: string }>;
+        }>;
+      }>;
+    };
+
+    expect(result.data[0].variants[0].tags.map((tag) => tag.label)).toEqual([
+      'GE limits',
+      'High investment required',
+      'Not viable',
+      'Safe',
+      'Very Slow to buy inputs',
+      'Very Slow to sell outputs',
+    ]);
+    expect(result.data[0].variants[0].tags[0].description).toContain('Coal requires 1,200/hour');
+    expect(result.data[0].variants[0].tags[1].description).toContain('14,400,000 GP');
+    expect(result.data[0].variants[0].tags[2].description).toContain('1.4 days');
+  });
+
+  it('includes auto-calculated tags on method detail variants', async () => {
+    const methodEntity = buildMethodFixture();
+    methodEntity.id = 'm1';
+    methodEntity.enabled = true;
+    methodEntity.variants = [methodEntity.variants[0]];
+    methodEntity.variants[0].id = 'v1';
+    methodEntity.variants[0].ioItems = [
+      Object.assign(new VariantIoItem(), {
+        id: 1,
+        itemId: 100,
+        quantity: 10,
+        type: 'input',
+        reason: null,
+        createdAt: new Date(),
+        variant: methodEntity.variants[0],
+      }),
+      Object.assign(new VariantIoItem(), {
+        id: 2,
+        itemId: 200,
+        quantity: 10,
+        type: 'output',
+        reason: null,
+        createdAt: new Date(),
+        variant: methodEntity.variants[0],
+      }),
+    ];
+
+    const methodRepo = {
+      findOne: jest.fn().mockResolvedValue(methodEntity),
+    } as unknown as Repository<Method>;
+
+    const historyRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      query: jest.fn().mockResolvedValue([]),
+    } as unknown as Repository<VariantHistory>;
+
+    const methodLikeRepo = {
+      count: jest.fn().mockResolvedValue(0),
+      exists: jest.fn().mockResolvedValue(false),
+    } as unknown as Repository<MethodLike>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      historyRepo,
+      methodLikeRepo,
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    jest.spyOn(service as any, 'getMethodProfits').mockResolvedValue({
+      v1: { low: -100, high: 200 },
+    });
+    jest.spyOn(service as any, 'getItemPrices').mockResolvedValue({
+      100: { high: 100, low: 90 },
+      200: { high: 150, low: 140 },
+    });
+    jest.spyOn(service as any, 'getItemVolumes24h').mockResolvedValue({
+      100: { high24h: 2400, low24h: 2400 },
+      200: { high24h: 2400, low24h: 2400 },
+    });
+
+    const result = (await service.findMethodDetailsWithProfit('m1')) as unknown as {
+      variants: Array<{ tags: Array<{ label: string }> }>;
+    };
+
+    expect(result.variants[0].tags).toEqual([
+      expect.objectContaining({ label: 'Risky to lose money' }),
+    ]);
   });
 
   it('denies method detail for disabled method when user is not super_admin', async () => {

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -1238,18 +1238,18 @@ describe('MethodsService variantCount', () => {
     )) as {
       data: Array<{
         variants: Array<{
-          tags: Array<{ label: string; description: string }>;
+          tags: Array<{ label: string; description: string; severity: number }>;
         }>;
       }>;
     };
 
-    expect(result.data[0].variants[0].tags.map((tag) => tag.label)).toEqual([
-      'GE limits',
-      'High investment required',
-      'Not viable',
-      'Safe',
-      'Very Slow to buy inputs',
-      'Very Slow to sell outputs',
+    expect(result.data[0].variants[0].tags.map((tag) => [tag.label, tag.severity])).toEqual([
+      ['GE limits', 2],
+      ['High investment required', 2],
+      ['Not viable', 3],
+      ['Safe', 1],
+      ['Very Slow to buy inputs', 2],
+      ['Very Slow to sell outputs', 2],
     ]);
     expect(result.data[0].variants[0].tags[0].description).toContain('Coal requires 1,200/hour');
     expect(result.data[0].variants[0].tags[1].description).toContain('14,400,000 GP');
@@ -1322,11 +1322,11 @@ describe('MethodsService variantCount', () => {
     });
 
     const result = (await service.findMethodDetailsWithProfit('m1')) as unknown as {
-      variants: Array<{ tags: Array<{ label: string }> }>;
+      variants: Array<{ tags: Array<{ label: string; severity: number }> }>;
     };
 
     expect(result.variants[0].tags).toEqual([
-      expect.objectContaining({ label: 'Risky to lose money' }),
+      expect.objectContaining({ label: 'Risky to lose money', severity: 3 }),
     ]);
   });
 

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -30,6 +30,11 @@ import { ConfigService } from '@nestjs/config';
 import { User } from '../auth/entities/user.entity';
 import { calculateMarketImpact, type MarketImpactResult } from './market-impact-calculator';
 import { Item } from '../items/entities/item.entity';
+import {
+  buildVariantTags,
+  type VariantSafety24hStats,
+  type VariantTagItemMetadata,
+} from './variant-tags';
 
 // Definimos tipos para mayor seguridad
 interface Profit {
@@ -46,6 +51,13 @@ interface ItemPrice {
 interface ItemVolume24h {
   high24h?: number;
   low24h?: number;
+}
+
+interface VariantSafety24hRow {
+  variantId?: string;
+  minLowProfit?: number | string;
+  minHighProfit?: number | string;
+  sampleCount?: number | string;
 }
 
 interface VariantIoQuantity {
@@ -1670,6 +1682,81 @@ export class MethodsService implements OnModuleDestroy {
     return result;
   }
 
+  private async getItemMetadata(ids: number[]): Promise<Record<number, VariantTagItemMetadata>> {
+    if (!this.itemRepo || ids.length === 0) return {};
+
+    const uniqueIds = [...new Set(ids)].filter((id) => Number.isInteger(id) && id > 0);
+    if (uniqueIds.length === 0) return {};
+
+    const items = await this.itemRepo.find({
+      where: { id: In(uniqueIds) },
+      select: {
+        id: true,
+        name: true,
+        buyLimit: true,
+      },
+    });
+
+    return items.reduce<Record<number, VariantTagItemMetadata>>((acc, item) => {
+      acc[item.id] = {
+        name: item.name,
+        buyLimit: item.buyLimit,
+      };
+      return acc;
+    }, {});
+  }
+
+  private async getVariantSafety24hStats(
+    variantIds: string[],
+    since: Date,
+  ): Promise<Record<string, VariantSafety24hStats>> {
+    if (variantIds.length === 0 || typeof this.historyRepo.query !== 'function') {
+      return {};
+    }
+
+    const placeholders = variantIds.map((_, index) => `$${index + 1}`).join(', ');
+    const sinceParam = variantIds.length + 1;
+    const rawRows = (await this.historyRepo.query(
+      `
+        SELECT
+          variant_id AS "variantId",
+          MIN(low_profit::float) AS "minLowProfit",
+          MIN(high_profit::float) AS "minHighProfit",
+          COUNT(*)::int AS "sampleCount"
+        FROM variant_history
+        WHERE variant_id IN (${placeholders})
+          AND "timestamp" >= $${sinceParam}
+        GROUP BY variant_id
+      `,
+      [...variantIds, since.toISOString()],
+    )) as unknown;
+
+    const rows = Array.isArray(rawRows) ? (rawRows as VariantSafety24hRow[]) : [];
+    return rows.reduce<Record<string, VariantSafety24hStats>>((acc, row) => {
+      if (typeof row.variantId !== 'string' || row.variantId.length === 0) {
+        return acc;
+      }
+
+      const minLowProfit = Number(row.minLowProfit);
+      const minHighProfit = Number(row.minHighProfit);
+      const sampleCount = Number(row.sampleCount);
+      if (
+        !Number.isFinite(minLowProfit) ||
+        !Number.isFinite(minHighProfit) ||
+        !Number.isFinite(sampleCount)
+      ) {
+        return acc;
+      }
+
+      acc[row.variantId] = {
+        minLowProfit,
+        minHighProfit,
+        sampleCount,
+      };
+      return acc;
+    }, {});
+  }
+
   private collectItemIdsFromVariants(
     variants: Array<{ inputs: VariantIoQuantity[]; outputs: VariantIoQuantity[] }>,
   ): number[] {
@@ -2214,11 +2301,17 @@ export class MethodsService implements OnModuleDestroy {
 
     // Enriquecemos la lista (filtrada o no) con la información de profit proveniente de Redis
     const itemIds = this.collectItemIdsFromMethods(methodsToProcess);
-    const [allProfits, pricesByItem, volumes24hByItem] = await Promise.all([
-      this.getAllMethodsProfits(),
-      this.getItemPrices(itemIds),
-      this.getItemVolumes24h(itemIds),
-    ]);
+    const variantIds = methodsToProcess.flatMap((method) =>
+      method.variants.map((variant) => variant.id),
+    );
+    const [allProfits, pricesByItem, volumes24hByItem, itemMetadataById, safety24hByVariantId] =
+      await Promise.all([
+        this.getAllMethodsProfits(),
+        this.getItemPrices(itemIds),
+        this.getItemVolumes24h(itemIds),
+        this.getItemMetadata(itemIds),
+        this.getVariantSafety24hStats(variantIds, new Date(Date.now() - 24 * 60 * 60 * 1000)),
+      ]);
     const selectedSkill = filters.skill?.trim().toLowerCase() || undefined;
 
     let enrichedMethods = methodsToProcess
@@ -2267,6 +2360,21 @@ export class MethodsService implements OnModuleDestroy {
             outputMarketImpactSlow: marketImpact.outputMarketImpactSlow,
             marketImpactInstant: marketImpact.marketImpactInstant,
             marketImpactSlow: marketImpact.marketImpactSlow,
+            tags: buildVariantTags({
+              variant,
+              pricesByItem,
+              volumes24hByItem,
+              itemMetadataById,
+              lowProfit: profit.low,
+              highProfit: profit.high,
+              inputMarketImpactInstant: marketImpact.inputMarketImpactInstant,
+              inputMarketImpactSlow: marketImpact.inputMarketImpactSlow,
+              outputMarketImpactInstant: marketImpact.outputMarketImpactInstant,
+              outputMarketImpactSlow: marketImpact.outputMarketImpactSlow,
+              marketImpactInstant: marketImpact.marketImpactInstant,
+              marketImpactSlow: marketImpact.marketImpactSlow,
+              safety24h: safety24hByVariantId[variant.id] ?? null,
+            }),
           };
 
           if (selectedSkill) {
@@ -2485,23 +2593,38 @@ export class MethodsService implements OnModuleDestroy {
       this.findOne(id),
     );
     const itemIds = this.collectItemIdsFromVariants(methodDto.variants);
-    const [allProfits, pricesByItem, volumes24hByItem] = await Promise.all([
-      this.timeMethodDetailsStep(perfLogsEnabled, scope, 'getMethodProfits', () =>
-        this.getMethodProfits(methodDto.id),
-      ),
-      this.timeMethodDetailsStep(
-        perfLogsEnabled,
-        scope,
-        `getItemPrices items=${itemIds.length}`,
-        () => this.getItemPrices(itemIds),
-      ),
-      this.timeMethodDetailsStep(
-        perfLogsEnabled,
-        scope,
-        `getItemVolumes24h items=${itemIds.length}`,
-        () => this.getItemVolumes24h(itemIds),
-      ),
-    ]);
+    const variantIds = methodDto.variants.map((variant) => variant.id);
+    const [allProfits, pricesByItem, volumes24hByItem, itemMetadataById, safety24hByVariantId] =
+      await Promise.all([
+        this.timeMethodDetailsStep(perfLogsEnabled, scope, 'getMethodProfits', () =>
+          this.getMethodProfits(methodDto.id),
+        ),
+        this.timeMethodDetailsStep(
+          perfLogsEnabled,
+          scope,
+          `getItemPrices items=${itemIds.length}`,
+          () => this.getItemPrices(itemIds),
+        ),
+        this.timeMethodDetailsStep(
+          perfLogsEnabled,
+          scope,
+          `getItemVolumes24h items=${itemIds.length}`,
+          () => this.getItemVolumes24h(itemIds),
+        ),
+        this.timeMethodDetailsStep(
+          perfLogsEnabled,
+          scope,
+          `getItemMetadata items=${itemIds.length}`,
+          () => this.getItemMetadata(itemIds),
+        ),
+        this.timeMethodDetailsStep(
+          perfLogsEnabled,
+          scope,
+          `getVariantSafety24hStats variants=${variantIds.length}`,
+          () =>
+            this.getVariantSafety24hStats(variantIds, new Date(Date.now() - 24 * 60 * 60 * 1000)),
+        ),
+      ]);
 
     const enrichedVariants = await this.timeMethodDetailsStep(
       perfLogsEnabled,
@@ -2547,6 +2670,21 @@ export class MethodsService implements OnModuleDestroy {
               outputMarketImpactSlow: marketImpact.outputMarketImpactSlow,
               marketImpactInstant: marketImpact.marketImpactInstant,
               marketImpactSlow: marketImpact.marketImpactSlow,
+              tags: buildVariantTags({
+                variant,
+                pricesByItem,
+                volumes24hByItem,
+                itemMetadataById,
+                lowProfit: profit.low,
+                highProfit: profit.high,
+                inputMarketImpactInstant: marketImpact.inputMarketImpactInstant,
+                inputMarketImpactSlow: marketImpact.inputMarketImpactSlow,
+                outputMarketImpactInstant: marketImpact.outputMarketImpactInstant,
+                outputMarketImpactSlow: marketImpact.outputMarketImpactSlow,
+                marketImpactInstant: marketImpact.marketImpactInstant,
+                marketImpactSlow: marketImpact.marketImpactSlow,
+                safety24h: safety24hByVariantId[variant.id] ?? null,
+              }),
               trendLastHour: trends.lastHour,
               trendLast24h: trends.last24h,
               trendLastWeek: trends.lastWeek,

--- a/src/methods/variant-tags.ts
+++ b/src/methods/variant-tags.ts
@@ -1,0 +1,342 @@
+const HOURS_IN_DAY = 24;
+const GE_WINDOW_HOURS = 4;
+const HIGH_INVESTMENT_THRESHOLD_GP = 10_000_000;
+const VERY_SLOW_MARKET_IMPACT_THRESHOLD = 24;
+
+const integerFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+});
+const decimalFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
+export interface VariantTag {
+  label: string;
+  description: string;
+}
+
+export interface VariantTagVariantItem {
+  id: number;
+  quantity: number;
+}
+
+export interface VariantTagVariant {
+  inputs: VariantTagVariantItem[];
+  outputs: VariantTagVariantItem[];
+}
+
+export interface VariantTagPrice {
+  high?: number;
+  low?: number;
+}
+
+export interface VariantTagVolume24h {
+  high24h?: number;
+  low24h?: number;
+}
+
+export interface VariantTagItemMetadata {
+  name?: string | null;
+  buyLimit?: number | null;
+}
+
+export interface VariantSafety24hStats {
+  minLowProfit: number;
+  minHighProfit: number;
+  sampleCount: number;
+}
+
+export interface BuildVariantTagsInput {
+  variant: VariantTagVariant;
+  pricesByItem: Record<number, VariantTagPrice>;
+  volumes24hByItem: Record<number, VariantTagVolume24h>;
+  itemMetadataById: Record<number, VariantTagItemMetadata>;
+  lowProfit: number;
+  highProfit: number;
+  inputMarketImpactInstant: number;
+  inputMarketImpactSlow: number;
+  outputMarketImpactInstant: number;
+  outputMarketImpactSlow: number;
+  marketImpactInstant: number;
+  marketImpactSlow: number;
+  safety24h?: VariantSafety24hStats | null;
+}
+
+interface SideVolumeDetail {
+  itemId: number;
+  itemName: string;
+  quantity: number;
+  instantVolumePerHour: number | null;
+  slowVolumePerHour: number | null;
+  instantShare: number;
+  slowShare: number;
+}
+
+const toFiniteNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const toPositiveNumberOrNull = (value: unknown): number | null => {
+  const parsed = toFiniteNumberOrNull(value);
+  if (parsed == null || parsed <= 0) return null;
+  return parsed;
+};
+
+const formatWholeNumber = (value: number): string => integerFormatter.format(Math.round(value));
+
+const formatGp = (value: number): string => `${formatWholeNumber(value)} GP`;
+
+const formatDays = (value: number): string => {
+  const formatted = decimalFormatter.format(value);
+  return `${formatted} ${value === 1 ? 'day' : 'days'}`;
+};
+
+const getItemName = (
+  itemId: number,
+  itemMetadataById: Record<number, VariantTagItemMetadata>,
+): string => {
+  const name = itemMetadataById[itemId]?.name?.trim();
+  return name && name.length > 0 ? name : `Item ${itemId}`;
+};
+
+const getInputUnitCost = (
+  itemId: number,
+  pricesByItem: Record<number, VariantTagPrice>,
+): number => {
+  const price = pricesByItem[itemId];
+  if (!price) return 0;
+
+  const high = toFiniteNumberOrNull(price.high);
+  const low = toFiniteNumberOrNull(price.low);
+  return Math.max(high ?? 0, low ?? 0, 0);
+};
+
+const getVolumePerHour = (
+  side: 'input' | 'output',
+  mode: 'instant' | 'slow',
+  itemId: number,
+  volumes24hByItem: Record<number, VariantTagVolume24h>,
+): number | null => {
+  const volume = volumes24hByItem[itemId];
+  if (!volume) return null;
+
+  const raw =
+    side === 'input'
+      ? mode === 'instant'
+        ? toPositiveNumberOrNull(volume.high24h)
+        : toPositiveNumberOrNull(volume.low24h)
+      : mode === 'instant'
+        ? toPositiveNumberOrNull(volume.low24h)
+        : toPositiveNumberOrNull(volume.high24h);
+
+  if (raw == null) return null;
+  return raw / HOURS_IN_DAY;
+};
+
+const getShareFromVolumePerHour = (quantity: number, volumePerHour: number | null): number => {
+  const normalizedQuantity = Number.isFinite(quantity) ? Math.max(0, quantity) : 0;
+  if (normalizedQuantity === 0) return 0;
+  if (volumePerHour == null) return 1;
+  return normalizedQuantity / Math.max(1, volumePerHour);
+};
+
+const buildSideVolumeDetails = (
+  items: VariantTagVariantItem[],
+  side: 'input' | 'output',
+  volumes24hByItem: Record<number, VariantTagVolume24h>,
+  itemMetadataById: Record<number, VariantTagItemMetadata>,
+): SideVolumeDetail[] =>
+  items
+    .map((item) => {
+      const quantity = Number.isFinite(item.quantity) ? Math.max(0, item.quantity) : 0;
+      const instantVolumePerHour = getVolumePerHour(side, 'instant', item.id, volumes24hByItem);
+      const slowVolumePerHour = getVolumePerHour(side, 'slow', item.id, volumes24hByItem);
+
+      return {
+        itemId: item.id,
+        itemName: getItemName(item.id, itemMetadataById),
+        quantity,
+        instantVolumePerHour,
+        slowVolumePerHour,
+        instantShare: getShareFromVolumePerHour(quantity, instantVolumePerHour),
+        slowShare: getShareFromVolumePerHour(quantity, slowVolumePerHour),
+      };
+    })
+    .filter((detail) => detail.quantity > 0)
+    .sort((a, b) => Math.max(b.instantShare, b.slowShare) - Math.max(a.instantShare, a.slowShare));
+
+const buildVolumeBullet = (detail: SideVolumeDetail): string => {
+  const requiredPerHour = formatWholeNumber(detail.quantity);
+
+  if (detail.instantVolumePerHour == null || detail.slowVolumePerHour == null) {
+    return `- ${detail.itemName} requires ${requiredPerHour}/hour, but 24h volume data is incomplete.`;
+  }
+
+  return `- ${detail.itemName} requires ${requiredPerHour}/hour, versus about ${formatWholeNumber(
+    detail.instantVolumePerHour,
+  )}/hour traded instantly and ${formatWholeNumber(detail.slowVolumePerHour)}/hour traded slowly.`;
+};
+
+export const buildVariantTags = ({
+  variant,
+  pricesByItem,
+  volumes24hByItem,
+  itemMetadataById,
+  lowProfit,
+  highProfit,
+  inputMarketImpactInstant,
+  inputMarketImpactSlow,
+  outputMarketImpactInstant,
+  outputMarketImpactSlow,
+  marketImpactInstant,
+  marketImpactSlow,
+  safety24h,
+}: BuildVariantTagsInput): VariantTag[] => {
+  const tags: VariantTag[] = [];
+
+  const geLimitedInputs = variant.inputs
+    .map((input) => {
+      const quantity = Number.isFinite(input.quantity) ? Math.max(0, input.quantity) : 0;
+      const buyLimit = toPositiveNumberOrNull(itemMetadataById[input.id]?.buyLimit);
+      if (quantity === 0 || buyLimit == null) return null;
+
+      const hourlyLimit = buyLimit / GE_WINDOW_HOURS;
+      if (quantity <= hourlyLimit) return null;
+
+      return {
+        itemName: getItemName(input.id, itemMetadataById),
+        quantity,
+        buyLimit,
+        hourlyLimit,
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+
+  if (geLimitedInputs.length > 0) {
+    tags.push({
+      label: 'GE limits',
+      description: [
+        'Some required inputs exceed Grand Exchange buy limits.',
+        ...geLimitedInputs.map(
+          (item) =>
+            `- ${item.itemName} requires ${formatWholeNumber(
+              item.quantity,
+            )}/hour, while the GE buy limit is ${formatWholeNumber(
+              item.buyLimit,
+            )} every 4 hours (${formatWholeNumber(item.hourlyLimit)}/hour).`,
+        ),
+      ].join('\n'),
+    });
+  }
+
+  const totalInputCost = variant.inputs.reduce((sum, input) => {
+    const quantity = Number.isFinite(input.quantity) ? Math.max(0, input.quantity) : 0;
+    return sum + getInputUnitCost(input.id, pricesByItem) * quantity;
+  }, 0);
+
+  if (
+    totalInputCost > HIGH_INVESTMENT_THRESHOLD_GP &&
+    Number.isFinite(highProfit) &&
+    totalInputCost > highProfit
+  ) {
+    tags.push({
+      label: 'High investment required',
+      description: `This method requires a high upfront investment. One hour of inputs costs about ${formatGp(
+        totalInputCost,
+      )}, which is higher than the method's best-case hourly profit of ${formatGp(highProfit)}.`,
+    });
+  }
+
+  if (
+    Number.isFinite(lowProfit) &&
+    Number.isFinite(highProfit) &&
+    lowProfit < 0 &&
+    highProfit > 0
+  ) {
+    tags.push({
+      label: 'Risky to lose money',
+      description:
+        'This method can be profitable in the best case, but it can lose money in the worst case. Use caution.',
+    });
+  }
+
+  if (
+    marketImpactInstant > VERY_SLOW_MARKET_IMPACT_THRESHOLD &&
+    marketImpactSlow > VERY_SLOW_MARKET_IMPACT_THRESHOLD
+  ) {
+    const bestCaseDays = Math.min(marketImpactInstant, marketImpactSlow) / HOURS_IN_DAY;
+    tags.push({
+      label: 'Not viable',
+      description: `This method has extreme market impact. Even in the best case, operating at this one-hour scale may require about ${formatDays(
+        bestCaseDays,
+      )} to fully buy and sell through the market.`,
+    });
+  }
+
+  if (
+    safety24h &&
+    safety24h.sampleCount > 0 &&
+    safety24h.minLowProfit >= 0 &&
+    safety24h.minHighProfit >= 0
+  ) {
+    tags.push({
+      label: 'Safe',
+      description:
+        'This method has stayed above break-even over the last 24 hours. Neither low profit nor high profit dropped below 0 GP.',
+    });
+  }
+
+  if (
+    inputMarketImpactInstant > VERY_SLOW_MARKET_IMPACT_THRESHOLD &&
+    inputMarketImpactSlow > VERY_SLOW_MARKET_IMPACT_THRESHOLD
+  ) {
+    const inputBullets = buildSideVolumeDetails(
+      variant.inputs,
+      'input',
+      volumes24hByItem,
+      itemMetadataById,
+    ).map(buildVolumeBullet);
+
+    tags.push({
+      label: 'Very Slow to buy inputs',
+      description: [
+        'The required input quantities are much higher than the market trades per hour, so buying inputs may take a long time at this scale.',
+        ...inputBullets,
+      ].join('\n'),
+    });
+  }
+
+  if (
+    outputMarketImpactInstant > VERY_SLOW_MARKET_IMPACT_THRESHOLD &&
+    outputMarketImpactSlow > VERY_SLOW_MARKET_IMPACT_THRESHOLD
+  ) {
+    const outputBullets = buildSideVolumeDetails(
+      variant.outputs,
+      'output',
+      volumes24hByItem,
+      itemMetadataById,
+    ).map(buildVolumeBullet);
+
+    tags.push({
+      label: 'Very Slow to sell outputs',
+      description: [
+        'The generated output quantities are much higher than the market trades per hour, so selling outputs may take a long time at this scale.',
+        ...outputBullets,
+      ].join('\n'),
+    });
+  }
+
+  return tags;
+};

--- a/src/methods/variant-tags.ts
+++ b/src/methods/variant-tags.ts
@@ -14,6 +14,7 @@ const decimalFormatter = new Intl.NumberFormat('en-US', {
 export interface VariantTag {
   label: string;
   description: string;
+  severity: 1 | 2 | 3;
 }
 
 export interface VariantTagVariantItem {
@@ -227,6 +228,7 @@ export const buildVariantTags = ({
   if (geLimitedInputs.length > 0) {
     tags.push({
       label: 'GE limits',
+      severity: 2,
       description: [
         'Some required inputs exceed Grand Exchange buy limits.',
         ...geLimitedInputs.map(
@@ -253,6 +255,7 @@ export const buildVariantTags = ({
   ) {
     tags.push({
       label: 'High investment required',
+      severity: 2,
       description: `This method requires a high upfront investment. One hour of inputs costs about ${formatGp(
         totalInputCost,
       )}, which is higher than the method's best-case hourly profit of ${formatGp(highProfit)}.`,
@@ -267,6 +270,7 @@ export const buildVariantTags = ({
   ) {
     tags.push({
       label: 'Risky to lose money',
+      severity: 3,
       description:
         'This method can be profitable in the best case, but it can lose money in the worst case. Use caution.',
     });
@@ -279,6 +283,7 @@ export const buildVariantTags = ({
     const bestCaseDays = Math.min(marketImpactInstant, marketImpactSlow) / HOURS_IN_DAY;
     tags.push({
       label: 'Not viable',
+      severity: 3,
       description: `This method has extreme market impact. Even in the best case, operating at this one-hour scale may require about ${formatDays(
         bestCaseDays,
       )} to fully buy and sell through the market.`,
@@ -293,6 +298,7 @@ export const buildVariantTags = ({
   ) {
     tags.push({
       label: 'Safe',
+      severity: 1,
       description:
         'This method has stayed above break-even over the last 24 hours. Neither low profit nor high profit dropped below 0 GP.',
     });
@@ -311,6 +317,7 @@ export const buildVariantTags = ({
 
     tags.push({
       label: 'Very Slow to buy inputs',
+      severity: 2,
       description: [
         'The required input quantities are much higher than the market trades per hour, so buying inputs may take a long time at this scale.',
         ...inputBullets,
@@ -331,6 +338,7 @@ export const buildVariantTags = ({
 
     tags.push({
       label: 'Very Slow to sell outputs',
+      severity: 2,
       description: [
         'The generated output quantities are much higher than the market trades per hour, so selling outputs may take a long time at this scale.',
         ...outputBullets,


### PR DESCRIPTION
## Summary

- Add a shared variant tag calculator that derives auto-generated tags from profit ranges, Grand Exchange limits, market impact, item volumes, and 24h safety history.
- Expose `variant.tags` in method list and detail responses, including response contract updates and Swagger example coverage.
- Classify every tag with a `severity` level so clients can distinguish positive, warning, and critical signals consistently.
- Add service tests covering both the tag generation flow and the severity mapping.

## How to test

- `npm run lint`
- `npm test`
- `npm run build`

## Notes

- Tag severities are mapped as `1` for positive signals, `2` for warning-level constraints, and `3` for critical risk indicators.
