### PR TITLE
feat(methods): replace the list query param with show_only_free_to_play

### DIFF
--- a/src/methods/methods.controller.spec.ts
+++ b/src/methods/methods.controller.spec.ts
@@ -128,3 +128,56 @@ describe('MethodsController trending profit endpoint', () => {
     });
   });
 });
+
+describe('MethodsController list endpoint', () => {
+  it('forwards show_only_free_to_play to the service query object', async () => {
+    const svc: { listWithProfitResponse: jest.Mock } = {
+      listWithProfitResponse: jest.fn().mockResolvedValue({ data: { methods: [] }, meta: {} }),
+    };
+
+    const controller = new MethodsController(svc as unknown as MethodsService);
+    const req = { headers: { authorization: 'Bearer token' } } as unknown as Request;
+
+    await controller.findAll(
+      'craft',
+      '1',
+      '10',
+      'zezima',
+      'Skilling',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'true',
+      undefined,
+      undefined,
+      'all',
+      'highProfit',
+      'desc',
+      req,
+    );
+
+    expect(svc.listWithProfitResponse).toHaveBeenCalledWith({
+      page: '1',
+      perPage: '10',
+      username: 'zezima',
+      name: 'craft',
+      category: 'Skilling',
+      clickIntensity: undefined,
+      afkiness: undefined,
+      riskLevel: undefined,
+      givesExperience: undefined,
+      skill: undefined,
+      showProfitables: undefined,
+      show_only_free_to_play: 'true',
+      enabled: undefined,
+      likedByMe: undefined,
+      variants: 'all',
+      sortBy: 'highProfit',
+      order: 'desc',
+      authorization: 'Bearer token',
+    });
+  });
+});

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -128,9 +128,10 @@ export class MethodsController {
     description: 'true or false',
   })
   @ApiQuery({
-    name: 'members',
+    name: 'show_only_free_to_play',
     required: false,
-    description: 'true to return only members variants, false to return only free-to-play variants',
+    description:
+      'true to return only free-to-play variants. false or omitted returns both free-to-play and members variants',
   })
   @ApiQuery({
     name: 'enabled',
@@ -179,7 +180,7 @@ export class MethodsController {
     @Query('givesExperience') givesExperience?: string,
     @Query('skill') skill?: string,
     @Query('showProfitables') showProfitables?: string,
-    @Query('members') members?: string | boolean,
+    @Query('show_only_free_to_play') showOnlyFreeToPlay?: string | boolean,
     @Query('enabled') enabled?: string | boolean,
     @Query('likedByMe') likedByMe?: string | boolean,
     @Query('variants') variants?: string,
@@ -199,7 +200,7 @@ export class MethodsController {
       givesExperience,
       skill,
       showProfitables,
-      members,
+      show_only_free_to_play: showOnlyFreeToPlay,
       enabled,
       likedByMe,
       variants,

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -954,6 +954,33 @@ describe('MethodsService variantCount', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
+  it('throws when members and show_only_free_to_play are used together', async () => {
+    const methodRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    } as unknown as Repository<Method>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    await expect(
+      service.listWithProfitResponse({
+        page: '1',
+        perPage: '10',
+        members: 'false',
+        show_only_free_to_play: 'true',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
   it('sorts by likes and includes likedByMe when auth token is present', async () => {
     const methodOne = buildMethodFixture();
     methodOne.id = 'm1';

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -107,6 +107,7 @@ interface ListQuery {
   skill?: string;
   showProfitables?: string;
   members?: string | boolean;
+  show_only_free_to_play?: string | boolean;
   enabled?: string | boolean;
   likedByMe?: string | boolean;
   variants?: string;
@@ -354,6 +355,15 @@ export class MethodsService implements OnModuleDestroy {
     } = query;
 
     const enabledParsed = this.parseBooleanQueryParam(enabled, 'enabled');
+    const membersFilter = this.parseBooleanQueryParam(query.members, 'members');
+    const showOnlyFreeToPlayFilter = this.parseBooleanQueryParam(
+      query.show_only_free_to_play,
+      'show_only_free_to_play',
+    );
+
+    if (membersFilter != null && showOnlyFreeToPlayFilter != null) {
+      throw new BadRequestException('members and show_only_free_to_play cannot be used together');
+    }
 
     return {
       name,
@@ -366,7 +376,7 @@ export class MethodsService implements OnModuleDestroy {
       skill: skill ?? undefined,
       showProfitables:
         showProfitables === 'true' ? true : showProfitables === 'false' ? false : undefined,
-      members: this.parseBooleanQueryParam(query.members, 'members'),
+      members: showOnlyFreeToPlayFilter === true ? false : membersFilter,
       enabled: enabledParsed ?? true,
     };
   }

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -317,7 +317,7 @@ describe('Methods (e2e)', () => {
     });
   });
 
-  it('GET /methods?members=false&variants=all returns only free-to-play variants', async () => {
+  it('GET /methods?show_only_free_to_play=true&variants=all returns only free-to-play variants', async () => {
     const methodRepo = dataSource.getRepository(Method);
     const variantRepo = dataSource.getRepository(MethodVariant);
     const seed = buildMethodFixture();
@@ -370,7 +370,9 @@ describe('Methods (e2e)', () => {
     });
 
     const server = app.getHttpServer() as unknown as Server;
-    const res = await request(server).get('/methods?members=false&variants=all').expect(200);
+    const res = await request(server)
+      .get('/methods?show_only_free_to_play=true&variants=all')
+      .expect(200);
 
     const body = res.body as {
       data: { methods: Array<{ variants: Array<{ id: string; members: boolean }> }> };
@@ -379,6 +381,76 @@ describe('Methods (e2e)', () => {
     expect(body.data.methods).toHaveLength(1);
     expect(body.data.methods[0].variants[0]).toMatchObject({
       id: savedVariantA.id,
+      members: false,
+    });
+  });
+
+  it('GET /methods?show_only_free_to_play=false&variants=all does not filter out members variants', async () => {
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+    const seed = buildMethodFixture();
+
+    const savedMethod = await methodRepo.save({
+      name: seed.name,
+      slug: seed.slug,
+      description: seed.description,
+      category: seed.category,
+    });
+
+    const [variantA, variantB] = seed.variants;
+    const savedVariantA = await variantRepo.save({
+      label: variantA.label,
+      slug: variantA.slug,
+      description: variantA.description,
+      xpHour: variantA.xpHour,
+      clickIntensity: variantA.clickIntensity,
+      afkiness: variantA.afkiness,
+      riskLevel: variantA.riskLevel,
+      requirements: variantA.requirements,
+      recommendations: variantA.recommendations,
+      wilderness: variantA.wilderness,
+      members: false,
+      actionsPerHour: variantA.actionsPerHour,
+      method: savedMethod,
+    });
+
+    const savedVariantB = await variantRepo.save({
+      label: variantB.label,
+      slug: variantB.slug,
+      description: variantB.description,
+      xpHour: variantB.xpHour,
+      clickIntensity: variantB.clickIntensity,
+      afkiness: variantB.afkiness,
+      riskLevel: variantB.riskLevel,
+      requirements: variantB.requirements,
+      recommendations: variantB.recommendations,
+      wilderness: variantB.wilderness,
+      members: true,
+      actionsPerHour: variantB.actionsPerHour,
+      method: savedMethod,
+    });
+
+    mockRedisProfits({
+      [savedMethod.id]: {
+        [savedVariantA.id]: { low: 100, high: 200 },
+        [savedVariantB.id]: { low: 200, high: 400 },
+      },
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .get('/methods?show_only_free_to_play=false&variants=all')
+      .expect(200);
+
+    const body = res.body as {
+      data: { methods: Array<{ variants: Array<{ id: string; members: boolean }> }> };
+    };
+
+    expect(body.data.methods).toHaveLength(2);
+    expect(body.data.methods[0].variants[0]).toMatchObject({
+      members: true,
+    });
+    expect(body.data.methods[1].variants[0]).toMatchObject({
       members: false,
     });
   });


### PR DESCRIPTION
## Summary

- Replace the `GET /methods` list query parameter with `show_only_free_to_play`.
- Keep the existing filtering behavior by mapping `show_only_free_to_play=true` to free-to-play-only results and leaving `false` or omission unfiltered.
- Add controller, service, and end-to-end coverage for the new query parameter behavior.

## How to test

- `npm run lint`
- `CI=true npm test`
- `npm run build`

## Notes

- `GET /methods/trending-profit` still uses the existing `members` query parameter and was intentionally left unchanged in this PR.
