### PR TITLE
fix(methods): validate free-to-play variants against members-only items

### DIFF
--- a/src/common/filters/http-exception.filter.spec.ts
+++ b/src/common/filters/http-exception.filter.spec.ts
@@ -37,6 +37,44 @@ describe('HttpExceptionFilter', () => {
     });
   });
 
+  it('preserves custom error codes and details from structured HttpException responses', () => {
+    const filter = new HttpExceptionFilter();
+    const { host, response } = createHost();
+
+    filter.catch(
+      new BadRequestException({
+        code: 'F2P_VARIANT_CONTAINS_MEMBERS_ITEMS',
+        message: 'Free-to-play variants cannot include members-only items.',
+        details: {
+          variants: [
+            {
+              variantTitle: 'Variant A',
+              membersOnlyItems: [{ id: 100, name: 'Members item' }],
+            },
+          ],
+        },
+      }),
+      host,
+    );
+
+    expect(response.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(response.json).toHaveBeenCalledWith({
+      status: 'error',
+      error: {
+        code: 'F2P_VARIANT_CONTAINS_MEMBERS_ITEMS',
+        message: 'Free-to-play variants cannot include members-only items.',
+        details: {
+          variants: [
+            {
+              variantTitle: 'Variant A',
+              membersOnlyItems: [{ id: 100, name: 'Members item' }],
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('translates oversized body parser errors into 413 responses', () => {
     const filter = new HttpExceptionFilter();
     const { host, response } = createHost();

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -32,7 +32,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
       const rawResponse = exception.getResponse();
       return {
         status,
-        code: status,
+        code: this.extractCode(rawResponse) ?? status,
         message: this.extractMessage(rawResponse) ?? 'Internal server error',
         details: this.extractDetails(rawResponse),
       };
@@ -71,8 +71,17 @@ export class HttpExceptionFilter implements ExceptionFilter {
     return undefined;
   }
 
+  private extractCode(rawResponse: unknown): number | string | undefined {
+    if (!rawResponse || typeof rawResponse !== 'object') return undefined;
+    const value = (rawResponse as { code?: unknown }).code;
+    if (typeof value === 'number' || typeof value === 'string') return value;
+    return undefined;
+  }
+
   private extractDetails(rawResponse: unknown): unknown {
     if (!rawResponse || typeof rawResponse !== 'object') return undefined;
+    const explicitDetails = (rawResponse as { details?: unknown }).details;
+    if (explicitDetails !== undefined) return explicitDetails;
     const value = (rawResponse as { message?: unknown }).message;
     if (Array.isArray(value)) return value;
     return undefined;

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -1438,6 +1438,140 @@ describe('MethodsService variantCount', () => {
     expect(result.status).toBe('ok');
     expect(result.data.method.id).toBe('m1');
   });
+
+  it('rejects create when free-to-play variants include members-only items', async () => {
+    const createMethod = jest.fn();
+    const saveMethod = jest.fn();
+    const methodRepo = {
+      create: createMethod,
+      save: saveMethod,
+    } as unknown as Repository<Method>;
+
+    const itemRepo = {
+      find: jest.fn().mockResolvedValue([
+        { id: 100, name: 'Members item', members: true },
+        { id: 101, name: 'Another members item', members: true },
+        { id: 4151, name: 'Method icon', members: false },
+        { id: 4152, name: 'Variant icon', members: false },
+      ]),
+    } as unknown as Repository<Item>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+      itemRepo,
+    );
+
+    await expect(
+      service.create({
+        name: 'Test method',
+        icon_id: 4151,
+        variants: [
+          {
+            label: 'Variant A',
+            icon_id: 4152,
+            members: false,
+            inputs: [{ id: 100, quantity: 1, type: 'input' }],
+            outputs: [],
+          },
+          {
+            label: 'Variant B',
+            icon_id: 4152,
+            members: false,
+            inputs: [],
+            outputs: [{ id: 101, quantity: 1, type: 'output' }],
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      response: {
+        code: 'F2P_VARIANT_CONTAINS_MEMBERS_ITEMS',
+        details: {
+          variants: [
+            {
+              variantTitle: 'Variant A',
+              membersOnlyItems: [{ id: 100, name: 'Members item' }],
+            },
+            {
+              variantTitle: 'Variant B',
+              membersOnlyItems: [{ id: 101, name: 'Another members item' }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(createMethod).not.toHaveBeenCalled();
+    expect(saveMethod).not.toHaveBeenCalled();
+  });
+
+  it('rejects updateVariant when the resulting free-to-play variant includes members-only items', async () => {
+    const existingMethod = { id: 'm1' } as Method;
+    const existingVariant = Object.assign(new MethodVariant(), {
+      id: 'v1',
+      label: 'Existing F2P variant',
+      members: false,
+      method: existingMethod,
+      ioItems: [],
+    });
+
+    const saveVariant = jest.fn();
+    const variantRepo = {
+      findOne: jest.fn().mockResolvedValue(existingVariant),
+      save: saveVariant,
+    } as unknown as Repository<MethodVariant>;
+
+    const deleteIoItems = jest.fn();
+    const ioRepo = {
+      delete: deleteIoItems,
+    } as unknown as Repository<VariantIoItem>;
+
+    const itemRepo = {
+      find: jest.fn().mockResolvedValue([{ id: 100, name: 'Members item', members: true }]),
+    } as unknown as Repository<Item>;
+
+    const service = new MethodsService(
+      {} as Repository<Method>,
+      variantRepo,
+      ioRepo,
+      {} as Repository<VariantHistory>,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+      itemRepo,
+    );
+
+    await expect(
+      service.updateVariant('v1', {
+        inputs: [{ id: 100, quantity: 1, type: 'input' }],
+        outputs: [],
+      }),
+    ).rejects.toMatchObject({
+      response: {
+        code: 'F2P_VARIANT_CONTAINS_MEMBERS_ITEMS',
+        details: {
+          variants: [
+            {
+              variantTitle: 'Existing F2P variant',
+              membersOnlyItems: [{ id: 100, name: 'Members item' }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(deleteIoItems).not.toHaveBeenCalled();
+    expect(saveVariant).not.toHaveBeenCalled();
+  });
 });
 
 describe('MethodsService trending profit', () => {

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -65,6 +65,10 @@ interface VariantIoQuantity {
   quantity: number;
 }
 
+interface VariantItemPayload {
+  id: number;
+}
+
 interface ListFilters {
   name?: string;
   category?: string;
@@ -257,6 +261,22 @@ interface SkillSummaryBySkill {
   bestProfit: SkillSummaryMethod | null;
   bestAfk: SkillSummaryMethod | null;
   bestXp: SkillSummaryMethod | null;
+}
+
+interface VariantMembershipValidationDraft {
+  variantTitle: string;
+  members: boolean;
+  itemIds: number[];
+}
+
+interface MembersOnlyItemConflict {
+  id: number;
+  name: string;
+}
+
+interface VariantMembersItemConflict {
+  variantTitle: string;
+  membersOnlyItems: MembersOnlyItemConflict[];
 }
 
 @Injectable()
@@ -1208,8 +1228,125 @@ export class MethodsService implements OnModuleDestroy {
     await this.assertIconItemIdsExist([updateDto.icon_id]);
   }
 
+  private normalizeVariantTitle(title?: string | null): string {
+    const normalized = title?.trim();
+    return normalized && normalized.length > 0 ? normalized : 'Untitled variant';
+  }
+
+  private collectItemIdsFromVariantPayload(
+    inputs: VariantItemPayload[] = [],
+    outputs: VariantItemPayload[] = [],
+  ): number[] {
+    return [...inputs, ...outputs]
+      .map((item) => item.id)
+      .filter((itemId) => Number.isInteger(itemId));
+  }
+
+  private async assertFreeToPlayVariantsOnlyUseFreeToPlayItems(
+    variants: VariantMembershipValidationDraft[],
+  ): Promise<void> {
+    const freeToPlayVariants = variants.filter(
+      (variant) => !variant.members && variant.itemIds.length > 0,
+    );
+    if (freeToPlayVariants.length === 0) return;
+    if (!this.itemRepo) {
+      throw new Error('Item repository is not configured');
+    }
+
+    const uniqueItemIds = [...new Set(freeToPlayVariants.flatMap((variant) => variant.itemIds))];
+    const items = await this.itemRepo.find({
+      select: { id: true, name: true, members: true },
+      where: { id: In(uniqueItemIds) },
+    });
+    const itemById = new Map(items.map((item) => [item.id, item]));
+
+    const conflicts = freeToPlayVariants.reduce<VariantMembersItemConflict[]>((acc, variant) => {
+      const membersOnlyItemsById = new Map<number, MembersOnlyItemConflict>();
+      for (const itemId of variant.itemIds) {
+        const item = itemById.get(itemId);
+        if (item?.members === true) {
+          membersOnlyItemsById.set(item.id, {
+            id: item.id,
+            name: item.name,
+          });
+        }
+      }
+
+      const membersOnlyItems = [...membersOnlyItemsById.values()].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      );
+      if (membersOnlyItems.length > 0) {
+        acc.push({
+          variantTitle: variant.variantTitle,
+          membersOnlyItems,
+        });
+      }
+
+      return acc;
+    }, []);
+
+    if (conflicts.length === 0) return;
+
+    const conflictSummary = conflicts
+      .map(
+        (conflict) =>
+          `${conflict.variantTitle}: ${conflict.membersOnlyItems.map((item) => item.name).join(', ')}`,
+      )
+      .join(' | ');
+
+    throw new BadRequestException({
+      code: 'F2P_VARIANT_CONTAINS_MEMBERS_ITEMS',
+      message: `Free-to-play variants cannot include members-only items. Conflicts: ${conflictSummary}`,
+      details: {
+        variants: conflicts,
+      },
+    });
+  }
+
+  private async validateCreateVariantMembership(createDto: CreateMethodDto): Promise<void> {
+    await this.assertFreeToPlayVariantsOnlyUseFreeToPlayItems(
+      createDto.variants.map((variant) => ({
+        variantTitle: this.normalizeVariantTitle(variant.label),
+        members: variant.members ?? false,
+        itemIds: this.collectItemIdsFromVariantPayload(variant.inputs, variant.outputs),
+      })),
+    );
+  }
+
+  private async validateUpdateVariantMembership(
+    existingVariant: MethodVariant,
+    updateDto: UpdateVariantDto,
+  ): Promise<void> {
+    await this.assertFreeToPlayVariantsOnlyUseFreeToPlayItems([
+      {
+        variantTitle: this.normalizeVariantTitle(updateDto.label ?? existingVariant.label),
+        members: updateDto.members ?? existingVariant.members ?? false,
+        itemIds: this.collectItemIdsFromVariantPayload(updateDto.inputs, updateDto.outputs),
+      },
+    ]);
+  }
+
+  private async validateUpdateMethodVariantMembership(
+    method: Method,
+    updateDto: UpdateMethodDto,
+  ): Promise<void> {
+    const existingVariants = new Map(method.variants.map((variant) => [variant.id, variant]));
+    await this.assertFreeToPlayVariantsOnlyUseFreeToPlayItems(
+      (updateDto.variants ?? []).map((variant) => {
+        const existingVariant = variant.id ? existingVariants.get(variant.id) : undefined;
+
+        return {
+          variantTitle: this.normalizeVariantTitle(variant.label ?? existingVariant?.label),
+          members: variant.members ?? existingVariant?.members ?? false,
+          itemIds: this.collectItemIdsFromVariantPayload(variant.inputs, variant.outputs),
+        };
+      }),
+    );
+  }
+
   async create(createDto: CreateMethodDto): Promise<MethodDto> {
     await this.validateCreateIconIds(createDto);
+    await this.validateCreateVariantMembership(createDto);
 
     const { name, description, category, enabled, variants, icon_id } = createDto;
     const method = this.methodRepo.create({
@@ -1295,6 +1432,7 @@ export class MethodsService implements OnModuleDestroy {
     }
 
     await this.validateUpdateIconIds(method, updateDto);
+    await this.validateUpdateMethodVariantMembership(method, updateDto);
 
     const { variants = [], name, description, category, enabled, icon_id } = updateDto;
 
@@ -1453,6 +1591,7 @@ export class MethodsService implements OnModuleDestroy {
     if (!variant) throw new NotFoundException(`Variant ${id} not found`);
 
     await this.validateVariantIconId(dto);
+    await this.validateUpdateVariantMembership(variant, dto);
 
     const {
       inputs = [],

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -52,16 +52,28 @@ describe('Methods (e2e)', () => {
     ],
   });
 
-  const seedItems = async (...ids: number[]) => {
+  const seedItems = async (
+    ...items: Array<number | { id: number; members?: boolean; name?: string }>
+  ) => {
     const itemRepo = dataSource.getRepository(Item);
     await itemRepo.save(
-      ids.map((id) =>
-        buildItemFixture({
-          id,
-          name: `Item ${id}`,
-          iconPath: `Item_${id}.png`,
-        }),
-      ),
+      items.map((item) => {
+        const config =
+          typeof item === 'number'
+            ? { id: item, members: false, name: `Item ${item}` }
+            : {
+                id: item.id,
+                members: item.members ?? false,
+                name: item.name ?? `Item ${item.id}`,
+              };
+
+        return buildItemFixture({
+          id: config.id,
+          name: config.name,
+          iconPath: `Item_${config.id}.png`,
+          members: config.members,
+        });
+      }),
     );
   };
 
@@ -754,6 +766,67 @@ describe('Methods (e2e)', () => {
     expect(String(body.message)).toContain('999999');
   });
 
+  it('POST /methods rejects free-to-play variants that include members-only items', async () => {
+    await seedItems(
+      { id: 100, members: true, name: 'Abyssal whip' },
+      { id: 200, members: false, name: 'Lobster' },
+      { id: 300, members: true, name: 'Dragon bones' },
+      { id: 4151, members: false, name: 'Method icon' },
+      { id: 4152, members: false, name: 'Variant icon' },
+    );
+
+    const server = app.getHttpServer() as unknown as Server;
+    const payload = {
+      ...buildValidCreateMethodPayload(),
+      variants: [
+        {
+          label: 'F2P Cooking',
+          icon_id: 4152,
+          members: false,
+          inputs: [{ id: 100, quantity: 1, type: 'input' }],
+          outputs: [{ id: 200, quantity: 1, type: 'output' }],
+        },
+        {
+          label: 'F2P Prayer',
+          icon_id: 4152,
+          members: false,
+          inputs: [],
+          outputs: [{ id: 300, quantity: 1, type: 'output' }],
+        },
+      ],
+    };
+
+    const res = await request(server).post('/methods').send(payload).expect(400);
+
+    const body = res.body as {
+      status: string;
+      error: {
+        code: string;
+        message: string;
+        details: {
+          variants: Array<{
+            variantTitle: string;
+            membersOnlyItems: Array<{ id: number; name: string }>;
+          }>;
+        };
+      };
+    };
+
+    expect(body.status).toBe('error');
+    expect(body.error.code).toBe('F2P_VARIANT_CONTAINS_MEMBERS_ITEMS');
+    expect(body.error.message).toContain('Free-to-play variants cannot include members-only items');
+    expect(body.error.details.variants).toEqual([
+      {
+        variantTitle: 'F2P Cooking',
+        membersOnlyItems: [{ id: 100, name: 'Abyssal whip' }],
+      },
+      {
+        variantTitle: 'F2P Prayer',
+        membersOnlyItems: [{ id: 300, name: 'Dragon bones' }],
+      },
+    ]);
+  });
+
   it('PUT /methods/:id rejects icon_id values that do not exist in items', async () => {
     await seedItems(4151, 4152);
 
@@ -807,6 +880,80 @@ describe('Methods (e2e)', () => {
     expect(String(body.message)).toContain('999999');
   });
 
+  it('PUT /methods/:id rejects free-to-play variants that include members-only items', async () => {
+    await seedItems(
+      { id: 100, members: true, name: 'Abyssal whip' },
+      { id: 200, members: false, name: 'Lobster' },
+      { id: 4151, members: false, name: 'Method icon' },
+      { id: 4152, members: false, name: 'Variant icon' },
+    );
+
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+
+    const savedMethod = await methodRepo.save({
+      name: 'Editable method',
+      slug: 'editable-method',
+      iconId: 4151,
+      description: 'Safe markdown',
+      category: 'Skilling',
+      enabled: true,
+    });
+
+    const savedVariant = await variantRepo.save({
+      label: 'Existing F2P variant',
+      slug: 'existing-f2p-variant',
+      iconId: 4152,
+      description: null,
+      xpHour: null,
+      clickIntensity: 1,
+      afkiness: 1,
+      riskLevel: '1',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      members: false,
+      actionsPerHour: 100,
+      method: savedMethod,
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .put(`/methods/${savedMethod.id}`)
+      .send({
+        variants: [
+          {
+            id: savedVariant.id,
+            inputs: [{ id: 100, quantity: 1, type: 'input' }],
+            outputs: [{ id: 200, quantity: 1, type: 'output' }],
+          },
+        ],
+      })
+      .expect(400);
+
+    const body = res.body as {
+      status: string;
+      error: {
+        code: string;
+        details: {
+          variants: Array<{
+            variantTitle: string;
+            membersOnlyItems: Array<{ id: number; name: string }>;
+          }>;
+        };
+      };
+    };
+
+    expect(body.status).toBe('error');
+    expect(body.error.code).toBe('F2P_VARIANT_CONTAINS_MEMBERS_ITEMS');
+    expect(body.error.details.variants).toEqual([
+      {
+        variantTitle: 'Existing F2P variant',
+        membersOnlyItems: [{ id: 100, name: 'Abyssal whip' }],
+      },
+    ]);
+  });
+
   it('PUT /methods/variant/:id rejects icon_id values that do not exist in items', async () => {
     await seedItems(4151, 4152);
 
@@ -851,6 +998,75 @@ describe('Methods (e2e)', () => {
     const body = res.body as { message?: unknown };
     expect(String(body.message)).toContain('icon_id must reference an existing item');
     expect(String(body.message)).toContain('999999');
+  });
+
+  it('PUT /methods/variant/:id rejects free-to-play variants that include members-only items', async () => {
+    await seedItems(
+      { id: 100, members: true, name: 'Abyssal whip' },
+      { id: 200, members: false, name: 'Lobster' },
+      { id: 4151, members: false, name: 'Method icon' },
+      { id: 4152, members: false, name: 'Variant icon' },
+    );
+
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+
+    const savedMethod = await methodRepo.save({
+      name: 'Variant edit method',
+      slug: 'variant-edit-method',
+      iconId: 4151,
+      description: 'Safe markdown',
+      category: 'Skilling',
+      enabled: true,
+    });
+
+    const savedVariant = await variantRepo.save({
+      label: 'Variant edit variant',
+      slug: 'variant-edit-variant',
+      iconId: 4152,
+      description: null,
+      xpHour: null,
+      clickIntensity: 1,
+      afkiness: 1,
+      riskLevel: '1',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      members: false,
+      actionsPerHour: 100,
+      method: savedMethod,
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .put(`/methods/variant/${savedVariant.id}`)
+      .send({
+        inputs: [{ id: 100, quantity: 1, type: 'input' }],
+        outputs: [{ id: 200, quantity: 1, type: 'output' }],
+      })
+      .expect(400);
+
+    const body = res.body as {
+      status: string;
+      error: {
+        code: string;
+        details: {
+          variants: Array<{
+            variantTitle: string;
+            membersOnlyItems: Array<{ id: number; name: string }>;
+          }>;
+        };
+      };
+    };
+
+    expect(body.status).toBe('error');
+    expect(body.error.code).toBe('F2P_VARIANT_CONTAINS_MEMBERS_ITEMS');
+    expect(body.error.details.variants).toEqual([
+      {
+        variantTitle: 'Variant edit variant',
+        membersOnlyItems: [{ id: 100, name: 'Abyssal whip' }],
+      },
+    ]);
   });
 
   it('POST /methods rejects unsafe script content in method.description', async () => {


### PR DESCRIPTION
## Summary

- Validate free-to-play method variants before saving and reject any variant that includes members-only input or output items.
- Return a structured API error with a stable custom code and detailed variant/item conflict metadata so the frontend can render the failure cleanly.
- Add unit and end-to-end coverage for create and update flows that hit the new free-to-play item validation.

## How to test

- `npm run lint`
- `npm test`
- `npm run build`

## Notes

- The API now returns `400 Bad Request` with error code `F2P_VARIANT_CONTAINS_MEMBERS_ITEMS` when a free-to-play variant includes members-only items.
