### PR TITLE
feat(methods): expose variant tags and ignore filtered variants

### DIFF
--- a/src/methods/methods.controller.spec.ts
+++ b/src/methods/methods.controller.spec.ts
@@ -154,6 +154,7 @@ describe('MethodsController list endpoint', () => {
       undefined,
       undefined,
       'all',
+      ['safe', 'ge_limits'],
       'highProfit',
       'desc',
       req,
@@ -175,9 +176,23 @@ describe('MethodsController list endpoint', () => {
       enabled: undefined,
       likedByMe: undefined,
       variants: 'all',
+      ignoredTags: ['safe', 'ge_limits'],
       sortBy: 'highProfit',
       order: 'desc',
       authorization: 'Bearer token',
     });
+  });
+
+  it('returns the variant tags catalog from the service', () => {
+    const svc: { listVariantTagsResponse: jest.Mock } = {
+      listVariantTagsResponse: jest.fn().mockReturnValue({ data: { tags: [{ key: 'safe' }] } }),
+    };
+
+    const controller = new MethodsController(svc as unknown as MethodsService);
+
+    expect(controller.listVariantTags()).toEqual({
+      data: { tags: [{ key: 'safe' }] },
+    });
+    expect(svc.listVariantTagsResponse).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -27,6 +27,7 @@ import { CreateMethodDto, UpdateMethodDto, UpdateMethodBasicDto, UpdateVariantDt
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
 import type { AuthenticatedUser } from '../auth/auth.types';
+import { VARIANT_TAG_DEFINITIONS, VARIANT_TAG_QUERY_VALUES } from './variant-tags';
 
 interface PaginatedResult {
   data: any[];
@@ -76,6 +77,12 @@ const METHOD_EXAMPLE = {
     },
   ],
 };
+
+const METHOD_TAGS_EXAMPLE = VARIANT_TAG_DEFINITIONS.map((tag) => ({
+  key: tag.key,
+  label: tag.label,
+  severity: tag.severity,
+}));
 
 @ApiTags('methods')
 @Controller('methods')
@@ -156,6 +163,11 @@ export class MethodsController {
     description:
       'best (default) returns only the best-profit variant per method. all returns one method entry per variant.',
   })
+  @ApiQuery({
+    name: 'ignoredTags',
+    required: false,
+    description: `Comma-separated or repeated variant tag keys to ignore. Accepted values: ${VARIANT_TAG_QUERY_VALUES.join(', ')}`,
+  })
   @ApiQuery({ name: 'order', required: false, description: 'asc or desc' })
   @ApiOkResponse({
     description: 'Methods list',
@@ -184,6 +196,7 @@ export class MethodsController {
     @Query('enabled') enabled?: string | boolean,
     @Query('likedByMe') likedByMe?: string | boolean,
     @Query('variants') variants?: string,
+    @Query('ignoredTags') ignoredTags?: string | string[],
     @Query('sortBy') sortBy = 'highProfit',
     @Query('order') order = 'desc',
     @Req() req?: Request,
@@ -204,10 +217,30 @@ export class MethodsController {
       enabled,
       likedByMe,
       variants,
+      ignoredTags,
       sortBy,
       order,
       authorization: req?.headers.authorization,
     });
+  }
+
+  @Get('tags')
+  @ApiOperation({
+    summary: 'List available method variant tags',
+    description: 'Returns the catalog of variant tags accepted by ignoredTags.',
+  })
+  @ApiOkResponse({
+    description: 'Variant tags catalog',
+    schema: {
+      example: {
+        data: {
+          tags: METHOD_TAGS_EXAMPLE,
+        },
+      },
+    },
+  })
+  listVariantTags() {
+    return this.svc.listVariantTagsResponse();
   }
 
   @Get('skills/summary')

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -12,6 +12,7 @@ import type { ConfigService } from '@nestjs/config';
 import { User } from '../auth/entities/user.entity';
 import { BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { Item } from '../items/entities/item.entity';
+import { VARIANT_TAG_DEFINITIONS } from './variant-tags';
 
 type MethodDetailsWithProfitResult = Awaited<
   ReturnType<MethodsService['findMethodDetailsWithProfit']>
@@ -928,6 +929,26 @@ describe('MethodsService variantCount', () => {
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
+  it('returns the official variant tag catalog with severity', () => {
+    const service = new MethodsService(
+      {} as Repository<Method>,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    expect(service.listVariantTagsResponse()).toEqual({
+      data: {
+        tags: VARIANT_TAG_DEFINITIONS,
+      },
+    });
+  });
+
   it('throws when variants query param is invalid', async () => {
     const methodRepo = {
       find: jest.fn().mockResolvedValue([]),
@@ -950,6 +971,68 @@ describe('MethodsService variantCount', () => {
         page: '1',
         perPage: '10',
         variants: 'foo',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('parses ignoredTags query param from repeated and comma-separated values', async () => {
+    const methodRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    } as unknown as Repository<Method>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    const findAllWithProfitSpy = jest
+      .spyOn(service, 'findAllWithProfit')
+      .mockResolvedValue({ data: [], total: 0 });
+
+    await service.listWithProfitResponse({
+      page: '1',
+      perPage: '10',
+      ignoredTags: ['safe,ge_limits', 'not_viable'],
+    });
+
+    const filtersArg = findAllWithProfitSpy.mock.calls[0][3] as {
+      ignoredTags?: Set<string>;
+      enabled: boolean;
+    };
+
+    expect(filtersArg.enabled).toBe(true);
+    expect(filtersArg.ignoredTags).toEqual(new Set(['safe', 'ge_limits', 'not_viable']));
+  });
+
+  it('throws when ignoredTags query param contains unsupported tags', async () => {
+    const methodRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    } as unknown as Repository<Method>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    await expect(
+      service.listWithProfitResponse({
+        page: '1',
+        perPage: '10',
+        ignoredTags: 'unknown_tag',
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
@@ -1384,6 +1467,64 @@ describe('MethodsService variantCount', () => {
     expect(result.data[0].variants[0].tags[0].description).toContain('Coal requires 1,200/hour');
     expect(result.data[0].variants[0].tags[1].description).toContain('14,400,000 GP');
     expect(result.data[0].variants[0].tags[2].description).toContain('1.4 days');
+  });
+
+  it('filters out variants whose tags match ignoredTags', async () => {
+    const methodEntity = buildMethodFixture();
+    methodEntity.id = 'm1';
+    methodEntity.variants[0].id = 'v1';
+    methodEntity.variants[1].id = 'v2';
+
+    const methodRepo = {
+      find: jest.fn().mockResolvedValue([methodEntity]),
+    } as unknown as Repository<Method>;
+
+    const historyRepo = {
+      query: jest.fn().mockResolvedValue([
+        {
+          variantId: 'v2',
+          minLowProfit: 100,
+          minHighProfit: 200,
+          sampleCount: 3,
+        },
+      ]),
+    } as unknown as Repository<VariantHistory>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      historyRepo,
+      createMethodLikeRepo(),
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    jest.spyOn(service as any, 'getAllMethodsProfits').mockResolvedValue({
+      m1: {
+        v1: { low: 10, high: 20 },
+        v2: { low: 100, high: 200 },
+      },
+    });
+    jest.spyOn(service as any, 'getItemPrices').mockResolvedValue({});
+    jest.spyOn(service as any, 'getItemVolumes24h').mockResolvedValue({});
+
+    const result = (await service.findAllWithProfit(
+      1,
+      10,
+      undefined,
+      { enabled: true, ignoredTags: new Set(['safe']) },
+      { sortBy: 'highProfit', order: 'desc' },
+      {},
+      'all',
+    )) as {
+      data: Array<{ variants: Array<{ id: string }> }>;
+    };
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].variants[0].id).toBe('v1');
   });
 
   it('includes auto-calculated tags on method detail variants', async () => {

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -41,8 +41,13 @@ import {
 } from './dto/validation.constants';
 import {
   buildVariantTags,
+  getVariantTagQueryValue,
+  type VariantTagDefinition,
   type VariantSafety24hStats,
   type VariantTagItemMetadata,
+  type VariantTagQueryValue,
+  VARIANT_TAG_DEFINITIONS,
+  VARIANT_TAG_QUERY_VALUES,
 } from './variant-tags';
 
 // Definimos tipos para mayor seguridad
@@ -88,6 +93,7 @@ interface ListFilters {
   skill?: string;
   showProfitables?: boolean;
   members?: boolean;
+  ignoredTags?: Set<VariantTagQueryValue>;
   enabled: boolean;
 }
 
@@ -123,6 +129,7 @@ interface ListQuery {
   show_only_free_to_play?: string | boolean;
   enabled?: string | boolean;
   likedByMe?: string | boolean;
+  ignoredTags?: string | string[];
   variants?: string;
   sortBy?: string;
   order?: string;
@@ -393,6 +400,7 @@ export class MethodsService implements OnModuleDestroy {
       skill,
       showProfitables,
       enabled,
+      ignoredTags,
     } = query;
 
     const enabledParsed = this.parseBooleanQueryParam(enabled, 'enabled');
@@ -422,6 +430,7 @@ export class MethodsService implements OnModuleDestroy {
       skill: this.parseOptionalSkillQueryParam(skill),
       showProfitables: showProfitablesFilter,
       members: showOnlyFreeToPlayFilter === true ? false : membersFilter,
+      ignoredTags: this.parseIgnoredTagsQueryParam(ignoredTags),
       enabled: enabledParsed ?? true,
     };
   }
@@ -449,6 +458,30 @@ export class MethodsService implements OnModuleDestroy {
     }
 
     throw new BadRequestException('variants must be one of: best, all');
+  }
+
+  private parseIgnoredTagsQueryParam(
+    value: string | string[] | undefined,
+  ): Set<VariantTagQueryValue> | undefined {
+    if (value == null) return undefined;
+
+    const normalizedValues = (Array.isArray(value) ? value : [value])
+      .flatMap((entry) => entry.split(','))
+      .map((entry) => entry.trim().toLowerCase())
+      .filter((entry) => entry.length > 0);
+
+    if (normalizedValues.length === 0) return undefined;
+
+    const invalidValues = normalizedValues.filter(
+      (entry) => !VARIANT_TAG_QUERY_VALUES.includes(entry as VariantTagQueryValue),
+    );
+    if (invalidValues.length > 0) {
+      throw new BadRequestException(
+        `ignoredTags must contain only: ${VARIANT_TAG_QUERY_VALUES.join(', ')}`,
+      );
+    }
+
+    return new Set(normalizedValues as VariantTagQueryValue[]);
   }
 
   private parseTrendingProfitWindow(value: string | undefined): TrendingProfitWindow {
@@ -511,6 +544,20 @@ export class MethodsService implements OnModuleDestroy {
           : 'minCurrentProfit',
       ),
     };
+  }
+
+  private hasIgnoredVariantTag(
+    tags: Array<{ label: string }> | undefined,
+    ignoredTags: Set<VariantTagQueryValue> | undefined,
+  ): boolean {
+    if (!ignoredTags || ignoredTags.size === 0 || !Array.isArray(tags) || tags.length === 0) {
+      return false;
+    }
+
+    return tags.some((tag) => {
+      const queryValue = getVariantTagQueryValue(tag.label);
+      return queryValue != null && ignoredTags.has(queryValue);
+    });
   }
 
   private getExperienceForSkill(xpHour: XpHour | null | undefined, skill: string): number | null {
@@ -870,6 +917,14 @@ export class MethodsService implements OnModuleDestroy {
       data: { methods: result.data, user: userInfo },
       warnings,
       meta,
+    };
+  }
+
+  listVariantTagsResponse(): { data: { tags: VariantTagDefinition[] } } {
+    return {
+      data: {
+        tags: VARIANT_TAG_DEFINITIONS.map((tag) => ({ ...tag })),
+      },
     };
   }
 
@@ -2703,6 +2758,7 @@ export class MethodsService implements OnModuleDestroy {
           }
           if (filters.showProfitables && v.highProfit <= 0) return false;
           if (filters.members != null && v.members !== filters.members) return false;
+          if (this.hasIgnoredVariantTag(v.tags, filters.ignoredTags)) return false;
           return true;
         });
 

--- a/src/methods/variant-tags.ts
+++ b/src/methods/variant-tags.ts
@@ -11,6 +11,67 @@ const decimalFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 1,
 });
 
+const VARIANT_TAG_LABEL_BY_QUERY_VALUE = {
+  ge_limits: 'GE limits',
+  high_investment_required: 'High investment required',
+  risky_to_lose_money: 'Risky to lose money',
+  not_viable: 'Not viable',
+  safe: 'Safe',
+  very_slow_to_buy_inputs: 'Very Slow to buy inputs',
+  very_slow_to_sell_outputs: 'Very Slow to sell outputs',
+} as const;
+
+export type VariantTagQueryValue = keyof typeof VARIANT_TAG_LABEL_BY_QUERY_VALUE;
+
+const VARIANT_TAG_SEVERITY_BY_QUERY_VALUE: Record<VariantTagQueryValue, 1 | 2 | 3> = {
+  ge_limits: 2,
+  high_investment_required: 2,
+  risky_to_lose_money: 3,
+  not_viable: 3,
+  safe: 1,
+  very_slow_to_buy_inputs: 2,
+  very_slow_to_sell_outputs: 2,
+};
+
+export interface VariantTagDefinition {
+  key: VariantTagQueryValue;
+  label: string;
+  severity: 1 | 2 | 3;
+}
+
+export const VARIANT_TAG_QUERY_VALUES = Object.keys(
+  VARIANT_TAG_LABEL_BY_QUERY_VALUE,
+) as VariantTagQueryValue[];
+
+export const VARIANT_TAG_DEFINITIONS: VariantTagDefinition[] = VARIANT_TAG_QUERY_VALUES.map(
+  (key) => ({
+    key,
+    label: VARIANT_TAG_LABEL_BY_QUERY_VALUE[key],
+    severity: VARIANT_TAG_SEVERITY_BY_QUERY_VALUE[key],
+  }),
+);
+
+const VARIANT_TAG_DEFINITION_BY_QUERY_VALUE = new Map<VariantTagQueryValue, VariantTagDefinition>(
+  VARIANT_TAG_DEFINITIONS.map((definition) => [definition.key, definition]),
+);
+
+const VARIANT_TAG_QUERY_VALUE_BY_LABEL = new Map<string, VariantTagQueryValue>(
+  Object.entries(VARIANT_TAG_LABEL_BY_QUERY_VALUE).map(([queryValue, label]) => [
+    label,
+    queryValue as VariantTagQueryValue,
+  ]),
+);
+
+const getVariantTagDefinition = (queryValue: VariantTagQueryValue): VariantTagDefinition =>
+  VARIANT_TAG_DEFINITION_BY_QUERY_VALUE.get(queryValue) ?? {
+    key: queryValue,
+    label: VARIANT_TAG_LABEL_BY_QUERY_VALUE[queryValue],
+    severity: VARIANT_TAG_SEVERITY_BY_QUERY_VALUE[queryValue],
+  };
+
+export const getVariantTagQueryValue = (label: string): VariantTagQueryValue | undefined =>
+  VARIANT_TAG_QUERY_VALUE_BY_LABEL.get(label);
+
 export interface VariantTag {
   label: string;
   description: string;
@@ -226,9 +287,10 @@ export const buildVariantTags = ({
     .filter((entry): entry is NonNullable<typeof entry> => entry != null);
 
   if (geLimitedInputs.length > 0) {
+    const tagDefinition = getVariantTagDefinition('ge_limits');
     tags.push({
-      label: 'GE limits',
-      severity: 2,
+      label: tagDefinition.label,
+      severity: tagDefinition.severity,
       description: [
         'Some required inputs exceed Grand Exchange buy limits.',
         ...geLimitedInputs.map(
@@ -253,9 +315,10 @@ export const buildVariantTags = ({
     Number.isFinite(highProfit) &&
     totalInputCost > highProfit
   ) {
+    const tagDefinition = getVariantTagDefinition('high_investment_required');
     tags.push({
-      label: 'High investment required',
-      severity: 2,
+      label: tagDefinition.label,
+      severity: tagDefinition.severity,
       description: `This method requires a high upfront investment. One hour of inputs costs about ${formatGp(
         totalInputCost,
       )}, which is higher than the method's best-case hourly profit of ${formatGp(highProfit)}.`,
@@ -268,9 +331,10 @@ export const buildVariantTags = ({
     lowProfit < 0 &&
     highProfit > 0
   ) {
+    const tagDefinition = getVariantTagDefinition('risky_to_lose_money');
     tags.push({
-      label: 'Risky to lose money',
-      severity: 3,
+      label: tagDefinition.label,
+      severity: tagDefinition.severity,
       description:
         'This method can be profitable in the best case, but it can lose money in the worst case. Use caution.',
     });
@@ -281,9 +345,10 @@ export const buildVariantTags = ({
     marketImpactSlow > VERY_SLOW_MARKET_IMPACT_THRESHOLD
   ) {
     const bestCaseDays = Math.min(marketImpactInstant, marketImpactSlow) / HOURS_IN_DAY;
+    const tagDefinition = getVariantTagDefinition('not_viable');
     tags.push({
-      label: 'Not viable',
-      severity: 3,
+      label: tagDefinition.label,
+      severity: tagDefinition.severity,
       description: `This method has extreme market impact. Even in the best case, operating at this one-hour scale may require about ${formatDays(
         bestCaseDays,
       )} to fully buy and sell through the market.`,
@@ -296,9 +361,10 @@ export const buildVariantTags = ({
     safety24h.minLowProfit >= 0 &&
     safety24h.minHighProfit >= 0
   ) {
+    const tagDefinition = getVariantTagDefinition('safe');
     tags.push({
-      label: 'Safe',
-      severity: 1,
+      label: tagDefinition.label,
+      severity: tagDefinition.severity,
       description:
         'This method has stayed above break-even over the last 24 hours. Neither low profit nor high profit dropped below 0 GP.',
     });
@@ -315,9 +381,10 @@ export const buildVariantTags = ({
       itemMetadataById,
     ).map(buildVolumeBullet);
 
+    const tagDefinition = getVariantTagDefinition('very_slow_to_buy_inputs');
     tags.push({
-      label: 'Very Slow to buy inputs',
-      severity: 2,
+      label: tagDefinition.label,
+      severity: tagDefinition.severity,
       description: [
         'The required input quantities are much higher than the market trades per hour, so buying inputs may take a long time at this scale.',
         ...inputBullets,
@@ -336,9 +403,10 @@ export const buildVariantTags = ({
       itemMetadataById,
     ).map(buildVolumeBullet);
 
+    const tagDefinition = getVariantTagDefinition('very_slow_to_sell_outputs');
     tags.push({
-      label: 'Very Slow to sell outputs',
-      severity: 2,
+      label: tagDefinition.label,
+      severity: tagDefinition.severity,
       description: [
         'The generated output quantities are much higher than the market trades per hour, so selling outputs may take a long time at this scale.',
         ...outputBullets,

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -26,6 +26,23 @@ describe('Methods (e2e)', () => {
   let app: INestApplication;
   let dataSource: DataSource;
 
+  type CreateMethodPayload = {
+    name: string;
+    icon_id: number;
+    description: string;
+    category: string;
+    enabled: boolean;
+    variants: Array<{
+      label: string;
+      icon_id: number;
+      description?: string;
+      members?: boolean;
+      requirements?: Record<string, unknown>;
+      inputs: Array<{ id: number; quantity: number; type: 'input' | 'output'; reason?: string }>;
+      outputs: Array<{ id: number; quantity: number; type: 'input' | 'output'; reason?: string }>;
+    }>;
+  };
+
   const expectUnsafeMarkdownValidationMessage = (body: { message?: unknown }): void => {
     const messages = Array.isArray(body.message)
       ? body.message.map(String)
@@ -35,7 +52,7 @@ describe('Methods (e2e)', () => {
     ).toBe(true);
   };
 
-  const buildValidCreateMethodPayload = () => ({
+  const buildValidCreateMethodPayload = (): CreateMethodPayload => ({
     name: 'Validated method',
     icon_id: 4151,
     description: 'Texto **markdown** con [link](https://example.com)',
@@ -465,6 +482,78 @@ describe('Methods (e2e)', () => {
     expect(body.data.methods[1].variants[0]).toMatchObject({
       members: false,
     });
+  });
+
+  it('GET /methods?ignoredTags=safe&variants=all excludes variants that contain ignored tags', async () => {
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+    const historyRepo = dataSource.getRepository(VariantHistory);
+    const seed = buildMethodFixture();
+
+    const savedMethod = await methodRepo.save({
+      name: seed.name,
+      slug: seed.slug,
+      description: seed.description,
+      category: seed.category,
+    });
+
+    const [variantA, variantB] = seed.variants;
+    const savedVariantA = await variantRepo.save({
+      label: variantA.label,
+      slug: variantA.slug,
+      description: variantA.description,
+      xpHour: variantA.xpHour,
+      clickIntensity: variantA.clickIntensity,
+      afkiness: variantA.afkiness,
+      riskLevel: variantA.riskLevel,
+      requirements: variantA.requirements,
+      recommendations: variantA.recommendations,
+      wilderness: variantA.wilderness,
+      actionsPerHour: variantA.actionsPerHour,
+      method: savedMethod,
+    });
+
+    const savedVariantB = await variantRepo.save({
+      label: variantB.label,
+      slug: variantB.slug,
+      description: variantB.description,
+      xpHour: variantB.xpHour,
+      clickIntensity: variantB.clickIntensity,
+      afkiness: variantB.afkiness,
+      riskLevel: variantB.riskLevel,
+      requirements: variantB.requirements,
+      recommendations: variantB.recommendations,
+      wilderness: variantB.wilderness,
+      actionsPerHour: variantB.actionsPerHour,
+      method: savedMethod,
+    });
+
+    await historyRepo.save(
+      historyRepo.create({
+        variant: savedVariantB,
+        timestamp: new Date(),
+        lowProfit: 100,
+        highProfit: 200,
+      }),
+    );
+
+    mockRedisProfits({
+      [savedMethod.id]: {
+        [savedVariantA.id]: { low: 50, high: 150 },
+        [savedVariantB.id]: { low: 100, high: 200 },
+      },
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server).get('/methods?ignoredTags=safe&variants=all').expect(200);
+
+    const body = res.body as {
+      data: { methods: Array<{ variants: Array<{ id: string; tags: Array<{ label: string }> }> }> };
+    };
+
+    expect(body.data.methods).toHaveLength(1);
+    expect(body.data.methods[0].variants[0].id).toBe(savedVariantA.id);
+    expect(body.data.methods[0].variants[0].tags.map((tag) => tag.label)).not.toContain('Safe');
   });
 
   it('GET /methods/trending-profit returns methods ordered by profit growth', async () => {


### PR DESCRIPTION
## Summary

- Centralize method variant tag metadata so tag labels, severities, and query keys come from a single source of truth.
- Add `GET /methods/tags` to expose the public catalog of accepted variant tags.
- Add `ignoredTags` support to `GET /methods` so clients can exclude variants by one or more tag keys.
- Cover the new tag catalog and `ignoredTags` filtering behavior with controller, service, and e2e tests.

## How to test

- `npm run lint`
- `$env:CI='true'; npm test`
- `npm run build`
- `npm run start:dev`
- `curl.exe "http://localhost:3000/methods/tags"`
- `curl.exe "http://localhost:3000/methods?variants=all&ignoredTags=safe,ge_limits"`

## Notes

- `ignoredTags` accepts repeated query params and comma-separated values.
