### PR TITLE
feat(scheduler): add global scheduled jobs env toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Available variables:
 - `HEALTH_CHECK_TIMEOUT_MS`: Timeout (ms) for dependency checks in `/health`.
 - `RATE_LIMIT_TTL_SECONDS`: Rate limit window in seconds (default `60`).
 - `RATE_LIMIT_LIMIT`: Max requests per window (default `60`).
+- `SCHEDULED_JOBS_ENABLED`: Set to `false` to disable startup jobs and cron jobs in this instance while keeping the API available (default `true`).
 - `PRICE_CHANGE_WINDOW_SECONDS`: Price-change window in seconds for incremental refresh in `items:prices` (default `120`).
 - `ITEM_VOLUMES_INIT_ENABLED`: Set to `false` to skip item-volumes init backfill on startup (default `true`).
 - `CORS_ORIGINS`: Comma-separated allowed origins (e.g. `https://example.com,https://app.example.com`).

--- a/src/common/utils/parse-boolean-env.ts
+++ b/src/common/utils/parse-boolean-env.ts
@@ -1,0 +1,8 @@
+export const parseBooleanEnv = (value: string | undefined, fallback: boolean): boolean => {
+  if (!value) return fallback;
+
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+  if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+};

--- a/src/item-volumes/item-volumes.service.ts
+++ b/src/item-volumes/item-volumes.service.ts
@@ -7,6 +7,7 @@ import Redis from 'ioredis';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ItemVolumeBucket } from './entities/item-volume-bucket.entity';
+import { parseBooleanEnv } from '../common/utils/parse-boolean-env';
 
 interface WikiHourVolumeEntry {
   highPriceVolume?: number;
@@ -38,6 +39,7 @@ export class ItemVolumesService implements OnModuleInit, OnModuleDestroy {
   private readonly lockKey = 'lock:items:volumes:1h';
   private readonly lockTtlSeconds = 180;
   private readonly initEnabled: boolean;
+  private readonly jobsEnabled: boolean;
   private readonly userAgent =
     'osrstool-backend/1.0 (+https://github.com/CarmineBD/osrstool-backend)';
   private readonly releaseLockScript =
@@ -53,14 +55,16 @@ export class ItemVolumesService implements OnModuleInit, OnModuleDestroy {
   ) {
     const redisUrl = this.config.get<string>('REDIS_URL') as string;
     this.redis = new Redis(redisUrl);
-
-    const initFlag = (this.config.get<string>('ITEM_VOLUMES_INIT_ENABLED') ?? 'true')
-      .trim()
-      .toLowerCase();
-    this.initEnabled = initFlag !== 'false' && initFlag !== '0';
+    this.jobsEnabled = parseBooleanEnv(this.config.get<string>('SCHEDULED_JOBS_ENABLED'), true);
+    this.initEnabled = parseBooleanEnv(this.config.get<string>('ITEM_VOLUMES_INIT_ENABLED'), true);
   }
 
   async onModuleInit(): Promise<void> {
+    if (!this.jobsEnabled) {
+      this.logger.log('Skipping item volume jobs (SCHEDULED_JOBS_ENABLED=false).');
+      return;
+    }
+
     if (!this.initEnabled) {
       this.logger.log('Skipping item volume init pipeline (ITEM_VOLUMES_INIT_ENABLED=false).');
       return;
@@ -74,6 +78,10 @@ export class ItemVolumesService implements OnModuleInit, OnModuleDestroy {
 
   @Cron('15 0 * * * *')
   async handleHourlyJob(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
     await this.runVolumePipeline('cron', this.getCurrentHourTs());
   }
 

--- a/src/method-profit-refresher/method-profit-refresher.service.spec.ts
+++ b/src/method-profit-refresher/method-profit-refresher.service.spec.ts
@@ -66,4 +66,32 @@ describe('MethodProfitRefresherService', () => {
     expect(parsed.v1.low).toBe(36);
     expect(parsed.v1.high).toBe(55);
   });
+
+  it('skips scheduled refresh when SCHEDULED_JOBS_ENABLED is false', async () => {
+    const methodsService = {
+      findAll: jest.fn(),
+    };
+    const pricesService = {
+      getMany: jest.fn(),
+    };
+    const configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'REDIS_URL') return 'redis://localhost:6379';
+        if (key === 'SCHEDULED_JOBS_ENABLED') return 'false';
+        return undefined;
+      }),
+    };
+
+    const service = new MethodProfitRefresherService(
+      methodsService as unknown as MethodsService,
+      pricesService as unknown as PricesService,
+      configService as unknown as ConfigService,
+    );
+
+    await service.handleRefreshCron();
+
+    expect(methodsService.findAll).not.toHaveBeenCalled();
+    expect(pricesService.getMany).not.toHaveBeenCalled();
+    expect(redisCall).not.toHaveBeenCalled();
+  });
 });

--- a/src/method-profit-refresher/method-profit-refresher.service.ts
+++ b/src/method-profit-refresher/method-profit-refresher.service.ts
@@ -4,12 +4,14 @@ import Redis from 'ioredis';
 import { MethodsService } from '../methods/methods.service';
 import { PricesService } from '../prices/prices.service';
 import { ConfigService } from '@nestjs/config';
+import { parseBooleanEnv } from '../common/utils/parse-boolean-env';
 
 @Injectable()
 export class MethodProfitRefresherService {
   private readonly logger = new Logger(MethodProfitRefresherService.name);
   private readonly redis: Redis;
   private readonly methodsProfitsHashKey = 'methods:profits';
+  private readonly jobsEnabled: boolean;
 
   constructor(
     private readonly methodsService: MethodsService,
@@ -18,9 +20,18 @@ export class MethodProfitRefresherService {
   ) {
     const redisUrl = this.config.get<string>('REDIS_URL') as string;
     this.redis = new Redis(redisUrl);
+    this.jobsEnabled = parseBooleanEnv(this.config.get<string>('SCHEDULED_JOBS_ENABLED'), true);
   }
 
   @Cron('*/1 * * * *') // cada minuto
+  async handleRefreshCron(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
+    await this.refresh();
+  }
+
   async refresh(): Promise<void> {
     const { data: methods } = await this.methodsService.findAll(1, 1000);
     if (methods.length === 0) {

--- a/src/prices/prices.service.ts
+++ b/src/prices/prices.service.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ItemPriceRule, ItemPriceRuleType } from './entities/item-price-rule.entity';
+import { parseBooleanEnv } from '../common/utils/parse-boolean-env';
 
 interface Price {
   high?: number;
@@ -36,6 +37,7 @@ export class PricesService implements OnModuleInit {
   private readonly pricesHashKey = 'items:prices';
   private readonly legacyJsonKey = 'itemsPrices';
   private readonly changeWindowSeconds: number;
+  private readonly jobsEnabled: boolean;
   private isFirstFetch = true;
 
   constructor(
@@ -51,14 +53,28 @@ export class PricesService implements OnModuleInit {
     const parsedWindow = rawWindow ? Number.parseInt(rawWindow, 10) : NaN;
     this.changeWindowSeconds =
       Number.isFinite(parsedWindow) && parsedWindow > 0 ? parsedWindow : 120;
+    this.jobsEnabled = parseBooleanEnv(this.config.get<string>('SCHEDULED_JOBS_ENABLED'), true);
   }
 
   async onModuleInit() {
+    if (!this.jobsEnabled) {
+      this.logger.log('Skipping initial prices snapshot (SCHEDULED_JOBS_ENABLED=false).');
+      return;
+    }
+
     this.logger.log('Fetching initial prices snapshot');
     await this.fetchPrices(true);
   }
 
   @Cron('*/1 * * * *')
+  async handleFetchPricesCron(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
+    await this.fetchPrices();
+  }
+
   async fetchPrices(forceFull = false) {
     try {
       const { data } = await firstValueFrom(

--- a/src/variant-history/variant-history.service.spec.ts
+++ b/src/variant-history/variant-history.service.spec.ts
@@ -323,6 +323,17 @@ describe('VariantHistoryService', () => {
     expect(historyRepo.save).not.toHaveBeenCalled();
   });
 
+  it('skips scheduled capture when SCHEDULED_JOBS_ENABLED is false', async () => {
+    const { service, historyRepo } = createService({
+      SCHEDULED_JOBS_ENABLED: 'false',
+    });
+
+    await service.handleCaptureCron();
+
+    expect(historyRepo.save).not.toHaveBeenCalled();
+    expect(redisCall).not.toHaveBeenCalled();
+  });
+
   it('does not prune when pruning is disabled', async () => {
     const { service, historyRepo, history15mRepo } = createService();
 

--- a/src/variant-history/variant-history.service.ts
+++ b/src/variant-history/variant-history.service.ts
@@ -9,6 +9,7 @@ import { VariantHistoryDaily } from '../methods/entities/variant-history-daily.e
 import { VariantHistory } from '../methods/entities/variant-history.entity';
 import { VariantSnapshot } from '../methods/entities/variant-snapshot.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
+import { parseBooleanEnv } from '../common/utils/parse-boolean-env';
 import {
   HistoryAgg,
   HistoryGranularity,
@@ -26,6 +27,7 @@ export class VariantHistoryService {
   private readonly logger = new Logger(VariantHistoryService.name);
   private readonly redis: Redis;
   private readonly methodsProfitsHashKey = 'methods:profits';
+  private readonly jobsEnabled: boolean;
   private readonly pruneEnabled: boolean;
   private readonly rawRetentionHours: number;
   private readonly history15mRetentionDays: number;
@@ -53,7 +55,8 @@ export class VariantHistoryService {
   ) {
     const redisUrl = this.config.get<string>('REDIS_URL') as string;
     this.redis = new Redis(redisUrl);
-    this.pruneEnabled = this.parseBooleanEnv(
+    this.jobsEnabled = parseBooleanEnv(this.config.get<string>('SCHEDULED_JOBS_ENABLED'), true);
+    this.pruneEnabled = parseBooleanEnv(
       this.config.get<string>('VARIANT_HISTORY_PRUNE_ENABLED'),
       false,
     );
@@ -65,15 +68,6 @@ export class VariantHistoryService {
       this.config.get<string>('VARIANT_HISTORY_15M_RETENTION_DAYS'),
       90,
     );
-  }
-
-  private parseBooleanEnv(value: string | undefined, fallback: boolean): boolean {
-    if (!value) return fallback;
-
-    const normalized = value.trim().toLowerCase();
-    if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
-    if (['false', '0', 'no', 'off'].includes(normalized)) return false;
-    return fallback;
   }
 
   private parsePositiveIntEnv(value: string | undefined, fallback: number): number {
@@ -181,6 +175,14 @@ export class VariantHistoryService {
   }
 
   @Cron('*/5 * * * *')
+  async handleCaptureCron(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
+    await this.capture();
+  }
+
   async capture(): Promise<void> {
     const startedAt = Date.now();
     const lockValue = await this.acquireLock(this.captureLockKey, this.captureLockTtlSeconds);
@@ -627,6 +629,14 @@ export class VariantHistoryService {
   }
 
   @Cron('17 * * * *')
+  async handlePruneHistoryCron(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
+    await this.pruneHistory();
+  }
+
   async pruneHistory(): Promise<void> {
     if (!this.pruneEnabled) {
       return;


### PR DESCRIPTION
## Summary

- add a shared `SCHEDULED_JOBS_ENABLED` toggle to skip startup jobs and cron executions while keeping the API available
- apply the toggle across prices, item volumes, method profit refreshes, and variant history background services
- add unit coverage for disabled scheduled jobs in the method profit refresher and variant history services
- document the new environment variable in the README

## How to test

```bash
npm run lint
CI=true npm test
npm run build
```

## Notes

- run `CI=true npm test` as `$env:CI='true'; npm test` in PowerShell
- when `SCHEDULED_JOBS_ENABLED=false`, the API stays available but scheduled startup and cron work is skipped
