### PR TITLE
feat(methods): add variant action metadata

### DIFF
--- a/sql/2026-08-04-add-variant-action-type.sql
+++ b/sql/2026-08-04-add-variant-action-type.sql
@@ -1,0 +1,18 @@
+ALTER TABLE method_variants
+ADD COLUMN IF NOT EXISTS action_type varchar(32);
+
+ALTER TABLE variant_snapshots
+ADD COLUMN IF NOT EXISTS action_type varchar(32);
+
+UPDATE method_variants
+SET action_type = 'items'
+WHERE action_type IS NULL;
+
+UPDATE variant_snapshots snapshot
+SET action_type = variant.action_type
+FROM method_variants variant
+WHERE snapshot.variant_id = variant.id
+  AND snapshot.action_type IS NULL;
+
+ALTER TABLE method_variants
+ALTER COLUMN action_type SET NOT NULL;

--- a/sql/2026-08-04-make-variant-actions-per-hour-not-null.sql
+++ b/sql/2026-08-04-make-variant-actions-per-hour-not-null.sql
@@ -1,0 +1,6 @@
+UPDATE method_variants
+SET actions_per_hour = 0
+WHERE actions_per_hour IS NULL;
+
+ALTER TABLE method_variants
+ALTER COLUMN actions_per_hour SET NOT NULL;

--- a/src/methods/action-type.enum.ts
+++ b/src/methods/action-type.enum.ts
@@ -1,0 +1,6 @@
+export enum ActionType {
+  ITEMS = 'items',
+  KILLS = 'kills',
+  ROUNDS = 'rounds',
+  CHESTS = 'chests',
+}

--- a/src/methods/dto/create-variant.dto.ts
+++ b/src/methods/dto/create-variant.dto.ts
@@ -2,6 +2,7 @@
 import {
   ArrayMaxSize,
   IsBoolean,
+  IsEnum,
   IsInt,
   IsOptional,
   Max,
@@ -32,6 +33,7 @@ import { TrimString } from './transforms';
 import { VariantRequirementsDto } from './variant-requirements.dto';
 import { HasMaxRequirementEntries } from './validators/requirement-entry-count.validator';
 import { SKILL_KEY_VALUES } from './skill.constants';
+import { ActionType } from '../action-type.enum';
 
 const RISK_LEVEL_PATTERN = /^(100|[1-9]?\d)$/;
 
@@ -46,11 +48,13 @@ export class CreateVariantDto {
   @Min(1)
   icon_id: number;
 
-  @IsOptional()
   @IsInt()
   @Min(0)
   @Max(MAX_CLICK_INTENSITY)
-  actionsPerHour?: number;
+  actionsPerHour: number;
+
+  @IsEnum(ActionType)
+  actionType: ActionType;
 
   @IsOptional()
   @IsArray()

--- a/src/methods/dto/index.ts
+++ b/src/methods/dto/index.ts
@@ -7,3 +7,4 @@ export * from './method-response.dto';
 export * from './update-method-basic.dto';
 export * from './update-variant.dto';
 export * from './update-method-variant.dto';
+export * from '../action-type.enum';

--- a/src/methods/dto/method-response.dto.ts
+++ b/src/methods/dto/method-response.dto.ts
@@ -1,6 +1,7 @@
 // src/methods/dto/method-response.dto.ts
 import { IoItemDto } from './io-item.dto';
 import { XpHour, VariantRecommendations, VariantRequirements } from '../types';
+import { ActionType } from '../action-type.enum';
 
 export class VariantTagResponseDto {
   label: string;
@@ -16,6 +17,7 @@ export class VariantResponseDto {
   description?: string;
   xpHour?: XpHour;
   actionsPerHour?: number;
+  actionType?: ActionType;
   clickIntensity?: number;
   afkiness?: number;
   riskLevel?: string;

--- a/src/methods/dto/method.dto.ts
+++ b/src/methods/dto/method.dto.ts
@@ -1,4 +1,5 @@
 import { VariantRequirements, VariantRecommendations, XpHour } from '../types';
+import { ActionType } from '../action-type.enum';
 
 export interface VariantDto {
   id: string;
@@ -7,6 +8,7 @@ export interface VariantDto {
   inputs: { id: number; quantity: number; reason?: string | null }[];
   outputs: { id: number; quantity: number; reason?: string | null }[];
   actionsPerHour?: number;
+  actionType?: ActionType;
   label?: string;
   description?: string | null;
   clickIntensity?: number;
@@ -65,6 +67,7 @@ export class MethodDto {
       label: string;
       description: string | null;
       actionsPerHour: number;
+      actionType: ActionType;
       clickIntensity: number;
       afkiness: number;
       riskLevel: string;
@@ -105,6 +108,7 @@ export class MethodDto {
         label: variant.label,
         description: variant.description,
         actionsPerHour: variant.actionsPerHour,
+        actionType: variant.actionType,
         clickIntensity: variant.clickIntensity,
         afkiness: variant.afkiness,
         riskLevel: variant.riskLevel,

--- a/src/methods/dto/update-variant.dto.ts
+++ b/src/methods/dto/update-variant.dto.ts
@@ -2,6 +2,7 @@
 import {
   ArrayMaxSize,
   IsBoolean,
+  IsEnum,
   IsInt,
   IsOptional,
   Max,
@@ -32,6 +33,7 @@ import { TrimString } from './transforms';
 import { VariantRequirementsDto } from './variant-requirements.dto';
 import { HasMaxRequirementEntries } from './validators/requirement-entry-count.validator';
 import { SKILL_KEY_VALUES } from './skill.constants';
+import { ActionType } from '../action-type.enum';
 
 const RISK_LEVEL_PATTERN = /^(100|[1-9]?\d)$/;
 
@@ -48,11 +50,13 @@ export class UpdateVariantDto {
   @Min(1)
   icon_id?: number;
 
-  @IsOptional()
   @IsInt()
   @Min(0)
   @Max(MAX_CLICK_INTENSITY)
-  actionsPerHour?: number;
+  actionsPerHour: number;
+
+  @IsEnum(ActionType)
+  actionType: ActionType;
 
   @IsOptional()
   @IsArray()

--- a/src/methods/entities/variant-snapshot.entity.ts
+++ b/src/methods/entities/variant-snapshot.entity.ts
@@ -2,6 +2,7 @@ import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 't
 import { MethodVariant } from './variant.entity';
 import { Method } from './method.entity';
 import { XpHour, VariantRequirements, VariantRecommendations } from '../types';
+import { ActionType } from '../action-type.enum';
 
 @Entity('variant_snapshots')
 export class VariantSnapshot {
@@ -24,6 +25,9 @@ export class VariantSnapshot {
 
   @Column({ name: 'actions_per_hour', type: 'int', nullable: true })
   actionsPerHour?: number;
+
+  @Column({ name: 'action_type', type: 'varchar', length: 32, nullable: true })
+  actionType?: ActionType | null;
 
   @Column({ name: 'xp_hour', type: 'jsonb', nullable: true })
   xpHour?: XpHour | null;

--- a/src/methods/entities/variant.entity.ts
+++ b/src/methods/entities/variant.entity.ts
@@ -71,7 +71,6 @@ export class MethodVariant {
   @Column({
     name: 'actions_per_hour',
     type: 'int',
-    nullable: true,
   })
   actionsPerHour: number;
 

--- a/src/methods/entities/variant.entity.ts
+++ b/src/methods/entities/variant.entity.ts
@@ -13,6 +13,7 @@ import {
 import { Method } from './method.entity';
 import { VariantIoItem } from './io-item.entity';
 import { XpHour, VariantRequirements, VariantRecommendations } from '../types';
+import { ActionType } from '../action-type.enum';
 
 @Entity('method_variants')
 @Unique('UQ_variant_method_slug', ['method', 'slug'])
@@ -73,6 +74,13 @@ export class MethodVariant {
     nullable: true,
   })
   actionsPerHour: number;
+
+  @Column({
+    name: 'action_type',
+    type: 'varchar',
+    length: 32,
+  })
+  actionType: ActionType;
 
   @Column({ name: 'likes_count', type: 'int', default: 0 })
   likesCount?: number;

--- a/src/methods/helpers/requirements.spec.ts
+++ b/src/methods/helpers/requirements.spec.ts
@@ -1,5 +1,6 @@
 import { MethodDto } from '../dto/method.dto';
 import { computeMissingRequirements, filterMethodsByUserStats } from './requirements';
+import { ActionType } from '../action-type.enum';
 
 describe('requirements helpers', () => {
   const userInfo = {
@@ -22,6 +23,7 @@ describe('requirements helpers', () => {
           label: 'Lowercase requirement',
           inputs: [],
           outputs: [],
+          actionType: ActionType.ITEMS,
           requirements: {
             levels: [{ skill: 'magic', level: 77 }],
           },

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -53,6 +53,7 @@ const METHOD_EXAMPLE = {
       inputs: [{ id: 3144, quantity: 1, reason: null }],
       outputs: [{ id: 3145, quantity: 1, reason: null }],
       actionsPerHour: 1200,
+      actionType: 'items',
       clickIntensity: 2,
       afkiness: 2,
       riskLevel: 'low',

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -2271,6 +2271,8 @@ describe('MethodsService variantCount', () => {
           {
             label: 'Variant A',
             icon_id: 4152,
+            actionsPerHour: 100,
+            actionType: ActionType.ITEMS,
             members: false,
             inputs: [{ id: 100, quantity: 1, type: 'input' }],
             outputs: [],
@@ -2278,6 +2280,8 @@ describe('MethodsService variantCount', () => {
           {
             label: 'Variant B',
             icon_id: 4152,
+            actionsPerHour: 100,
+            actionType: ActionType.ITEMS,
             members: false,
             inputs: [],
             outputs: [{ id: 101, quantity: 1, type: 'output' }],
@@ -2346,6 +2350,8 @@ describe('MethodsService variantCount', () => {
 
     await expect(
       service.updateVariant('v1', {
+        actionsPerHour: 100,
+        actionType: ActionType.ITEMS,
         inputs: [{ id: 100, quantity: 1, type: 'input' }],
         outputs: [],
       }),

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -12,6 +12,7 @@ import { User } from '../auth/entities/user.entity';
 import { BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { Item } from '../items/entities/item.entity';
 import { VARIANT_TAG_DEFINITIONS } from './variant-tags';
+import { ActionType } from './action-type.enum';
 
 type MethodDetailsWithProfitResult = Awaited<
   ReturnType<MethodsService['findMethodDetailsWithProfit']>
@@ -56,6 +57,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 0,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [],
           method: {} as Method,
@@ -73,6 +75,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 0,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [],
           method: {} as Method,
@@ -148,6 +151,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 0,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [],
           method: {} as Method,
@@ -165,6 +169,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 0,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [],
           method: {} as Method,
@@ -253,6 +258,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 0,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [
             {
@@ -622,6 +628,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 800,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [],
           method: {} as Method,
@@ -639,6 +646,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 600,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [],
           method: {} as Method,
@@ -668,6 +676,7 @@ describe('MethodsService variantCount', () => {
           recommendations: null,
           wilderness: false,
           actionsPerHour: 500,
+          actionType: ActionType.ITEMS,
           createdAt: new Date(),
           ioItems: [],
           method: {} as Method,
@@ -2387,6 +2396,7 @@ describe('MethodsService trending profit', () => {
       wilderness: false,
       members: false,
       actionsPerHour: 0,
+      actionType: ActionType.ITEMS,
       createdAt: new Date(),
       ioItems: [],
       method: {} as Method,

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -2271,6 +2271,7 @@ export class MethodsService implements OnModuleDestroy {
         method,
         label: v.label,
         actionsPerHour: v.actionsPerHour,
+        actionType: v.actionType,
         xpHour: v.xpHour,
         clickIntensity: v.clickIntensity,
         afkiness: v.afkiness,

--- a/src/testing/fixtures.ts
+++ b/src/testing/fixtures.ts
@@ -2,6 +2,7 @@ import { Item } from '../items/entities/item.entity';
 import { Method } from '../methods/entities/method.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
 import { VariantIoItem } from '../methods/entities/io-item.entity';
+import { ActionType } from '../methods/action-type.enum';
 
 export const buildItemFixture = (overrides: Partial<Item> = {}): Item => {
   const base: Item = {
@@ -46,6 +47,7 @@ export const buildMethodFixture = (): Method => {
   variantA.wilderness = false;
   variantA.members = false;
   variantA.actionsPerHour = 600;
+  variantA.actionType = ActionType.ITEMS;
   variantA.ioItems = [
     Object.assign(new VariantIoItem(), {
       itemId: 100,
@@ -74,6 +76,7 @@ export const buildMethodFixture = (): Method => {
   variantB.wilderness = false;
   variantB.members = false;
   variantB.actionsPerHour = 800;
+  variantB.actionType = ActionType.ITEMS;
   variantB.ioItems = [
     Object.assign(new VariantIoItem(), {
       itemId: 100,

--- a/src/variant-snapshots/variant-snapshot.service.ts
+++ b/src/variant-snapshots/variant-snapshot.service.ts
@@ -25,6 +25,7 @@ export class VariantSnapshotService {
       method: variant.method,
       label: variant.label,
       actionsPerHour: variant.actionsPerHour,
+      actionType: variant.actionType,
       xpHour: variant.xpHour,
       clickIntensity: variant.clickIntensity,
       afkiness: variant.afkiness,

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -36,6 +36,8 @@ describe('Methods (e2e)', () => {
     variants: Array<{
       label: string;
       icon_id: number;
+      actionsPerHour?: number;
+      actionType?: ActionType;
       description?: string;
       members?: boolean;
       requirements?: Record<string, unknown>;
@@ -63,6 +65,8 @@ describe('Methods (e2e)', () => {
       {
         label: 'Validated variant',
         icon_id: 4152,
+        actionsPerHour: 2,
+        actionType: ActionType.ITEMS,
         description: 'Lista:\n- item 1\n- item 2',
         inputs: [{ id: 100, quantity: 1, type: 'input', reason: 'Reason text' }],
         outputs: [{ id: 200, quantity: 1, type: 'output', reason: 'Reason text' }],
@@ -870,6 +874,24 @@ describe('Methods (e2e)', () => {
     expect(String(body.message)).toContain('999999');
   });
 
+  it('POST /methods requires actionsPerHour for each variant', async () => {
+    await seedItems(100, 200, 4151, 4152);
+
+    const server = app.getHttpServer() as unknown as Server;
+    const payload = buildValidCreateMethodPayload();
+    delete payload.variants[0].actionsPerHour;
+
+    const res = await request(server).post('/methods').send(payload).expect(400);
+    const body = res.body as { message?: unknown };
+    const messages = Array.isArray(body.message)
+      ? body.message.map(String)
+      : [String(body.message)];
+
+    expect(
+      messages.some((message) => message.includes('actionsPerHour must be an integer number')),
+    ).toBe(true);
+  });
+
   it('POST /methods rejects free-to-play variants that include members-only items', async () => {
     await seedItems(
       { id: 100, members: true, name: 'Abyssal whip' },
@@ -886,6 +908,8 @@ describe('Methods (e2e)', () => {
         {
           label: 'F2P Cooking',
           icon_id: 4152,
+          actionsPerHour: 100,
+          actionType: ActionType.ITEMS,
           members: false,
           inputs: [{ id: 100, quantity: 1, type: 'input' }],
           outputs: [{ id: 200, quantity: 1, type: 'output' }],
@@ -893,6 +917,8 @@ describe('Methods (e2e)', () => {
         {
           label: 'F2P Prayer',
           icon_id: 4152,
+          actionsPerHour: 100,
+          actionType: ActionType.ITEMS,
           members: false,
           inputs: [],
           outputs: [{ id: 300, quantity: 1, type: 'output' }],
@@ -973,6 +999,8 @@ describe('Methods (e2e)', () => {
             id: savedVariant.id,
             label: 'Editable variant',
             icon_id: 4152,
+            actionsPerHour: 100,
+            actionType: ActionType.ITEMS,
             inputs: [],
             outputs: [],
           },
@@ -983,6 +1011,64 @@ describe('Methods (e2e)', () => {
     const body = res.body as { message?: unknown };
     expect(String(body.message)).toContain('icon_id must reference an existing item');
     expect(String(body.message)).toContain('999999');
+  });
+
+  it('PUT /methods/:id requires actionsPerHour for edited variants', async () => {
+    await seedItems(4151, 4152);
+
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+
+    const savedMethod = await methodRepo.save({
+      name: 'Editable method',
+      slug: 'editable-method',
+      iconId: 4151,
+      description: 'Safe markdown',
+      category: 'Skilling',
+      enabled: true,
+    });
+
+    const savedVariant = await variantRepo.save({
+      label: 'Editable variant',
+      slug: 'editable-variant',
+      iconId: 4152,
+      description: null,
+      xpHour: null,
+      clickIntensity: 1,
+      afkiness: 1,
+      riskLevel: '1',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      actionsPerHour: 100,
+      actionType: ActionType.ITEMS,
+      method: savedMethod,
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .put(`/methods/${savedMethod.id}`)
+      .send({
+        variants: [
+          {
+            id: savedVariant.id,
+            label: 'Editable variant',
+            icon_id: 4152,
+            inputs: [],
+            outputs: [],
+          },
+        ],
+      })
+      .expect(400);
+
+    const body = res.body as { message?: unknown };
+    const messages = Array.isArray(body.message)
+      ? body.message.map(String)
+      : [String(body.message)];
+
+    expect(
+      messages.some((message) => message.includes('actionsPerHour must be an integer number')),
+    ).toBe(true);
   });
 
   it('PUT /methods/:id rejects free-to-play variants that include members-only items', async () => {
@@ -1030,6 +1116,8 @@ describe('Methods (e2e)', () => {
         variants: [
           {
             id: savedVariant.id,
+            actionsPerHour: 100,
+            actionType: ActionType.ITEMS,
             inputs: [{ id: 100, quantity: 1, type: 'input' }],
             outputs: [{ id: 200, quantity: 1, type: 'output' }],
           },
@@ -1097,6 +1185,8 @@ describe('Methods (e2e)', () => {
       .put(`/methods/variant/${savedVariant.id}`)
       .send({
         icon_id: 999999,
+        actionsPerHour: 100,
+        actionType: ActionType.ITEMS,
         inputs: [],
         outputs: [],
       })
@@ -1105,6 +1195,57 @@ describe('Methods (e2e)', () => {
     const body = res.body as { message?: unknown };
     expect(String(body.message)).toContain('icon_id must reference an existing item');
     expect(String(body.message)).toContain('999999');
+  });
+
+  it('PUT /methods/variant/:id requires actionsPerHour', async () => {
+    await seedItems(4151, 4152);
+
+    const methodRepo = dataSource.getRepository(Method);
+    const variantRepo = dataSource.getRepository(MethodVariant);
+
+    const savedMethod = await methodRepo.save({
+      name: 'Variant edit method',
+      slug: 'variant-edit-method',
+      iconId: 4151,
+      description: 'Safe markdown',
+      category: 'Skilling',
+      enabled: true,
+    });
+
+    const savedVariant = await variantRepo.save({
+      label: 'Variant edit variant',
+      slug: 'variant-edit-variant',
+      iconId: 4152,
+      description: null,
+      xpHour: null,
+      clickIntensity: 1,
+      afkiness: 1,
+      riskLevel: '1',
+      requirements: null,
+      recommendations: null,
+      wilderness: false,
+      actionsPerHour: 100,
+      actionType: ActionType.ITEMS,
+      method: savedMethod,
+    });
+
+    const server = app.getHttpServer() as unknown as Server;
+    const res = await request(server)
+      .put(`/methods/variant/${savedVariant.id}`)
+      .send({
+        inputs: [],
+        outputs: [],
+      })
+      .expect(400);
+
+    const body = res.body as { message?: unknown };
+    const messages = Array.isArray(body.message)
+      ? body.message.map(String)
+      : [String(body.message)];
+
+    expect(
+      messages.some((message) => message.includes('actionsPerHour must be an integer number')),
+    ).toBe(true);
   });
 
   it('PUT /methods/variant/:id rejects free-to-play variants that include members-only items', async () => {
@@ -1149,6 +1290,8 @@ describe('Methods (e2e)', () => {
     const res = await request(server)
       .put(`/methods/variant/${savedVariant.id}`)
       .send({
+        actionsPerHour: 100,
+        actionType: ActionType.ITEMS,
         inputs: [{ id: 100, quantity: 1, type: 'input' }],
         outputs: [{ id: 200, quantity: 1, type: 'output' }],
       })
@@ -1300,6 +1443,8 @@ describe('Methods (e2e)', () => {
     const res = await request(server)
       .put(`/methods/variant/${savedVariant.id}?generateSnapshot=true`)
       .send({
+        actionsPerHour: 100,
+        actionType: ActionType.ITEMS,
         snapshotName: 'Snapshot title',
         snapshotDescription: '[x](javascript:alert(1))',
       })

--- a/test/methods.e2e-spec.ts
+++ b/test/methods.e2e-spec.ts
@@ -18,6 +18,7 @@ import { Method } from '../src/methods/entities/method.entity';
 import { MethodVariant } from '../src/methods/entities/variant.entity';
 import { VariantIoItem } from '../src/methods/entities/io-item.entity';
 import { VariantHistory } from '../src/methods/entities/variant-history.entity';
+import { ActionType } from '../src/methods/action-type.enum';
 import { createPgMemAdapter } from './utils/pg-mem';
 
 jest.mock('pg', () => createPgMemAdapter());
@@ -167,6 +168,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantA.recommendations,
       wilderness: variantA.wilderness,
       actionsPerHour: variantA.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -182,6 +184,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantB.recommendations,
       wilderness: variantB.wilderness,
       actionsPerHour: variantB.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -265,6 +268,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantA.recommendations,
       wilderness: variantA.wilderness,
       actionsPerHour: variantA.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -280,6 +284,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantB.recommendations,
       wilderness: variantB.wilderness,
       actionsPerHour: variantB.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -372,6 +377,7 @@ describe('Methods (e2e)', () => {
       wilderness: variantA.wilderness,
       members: false,
       actionsPerHour: variantA.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -388,6 +394,7 @@ describe('Methods (e2e)', () => {
       wilderness: variantB.wilderness,
       members: true,
       actionsPerHour: variantB.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -440,6 +447,7 @@ describe('Methods (e2e)', () => {
       wilderness: variantA.wilderness,
       members: false,
       actionsPerHour: variantA.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -456,6 +464,7 @@ describe('Methods (e2e)', () => {
       wilderness: variantB.wilderness,
       members: true,
       actionsPerHour: variantB.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -510,6 +519,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantA.recommendations,
       wilderness: variantA.wilderness,
       actionsPerHour: variantA.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -525,6 +535,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantB.recommendations,
       wilderness: variantB.wilderness,
       actionsPerHour: variantB.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -587,6 +598,7 @@ describe('Methods (e2e)', () => {
       recommendations: null,
       wilderness: false,
       actionsPerHour: 0,
+      actionType: ActionType.ITEMS,
       method: smallMethod,
     });
     const bigVariant = await variantRepo.save({
@@ -601,6 +613,7 @@ describe('Methods (e2e)', () => {
       recommendations: null,
       wilderness: false,
       actionsPerHour: 0,
+      actionType: ActionType.ITEMS,
       method: bigMethod,
     });
 
@@ -720,6 +733,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantA.recommendations,
       wilderness: variantA.wilderness,
       actionsPerHour: variantA.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -735,6 +749,7 @@ describe('Methods (e2e)', () => {
       recommendations: variantB.recommendations,
       wilderness: variantB.wilderness,
       actionsPerHour: variantB.actionsPerHour,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -944,6 +959,7 @@ describe('Methods (e2e)', () => {
       recommendations: null,
       wilderness: false,
       actionsPerHour: 100,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -1003,6 +1019,7 @@ describe('Methods (e2e)', () => {
       wilderness: false,
       members: false,
       actionsPerHour: 100,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -1071,6 +1088,7 @@ describe('Methods (e2e)', () => {
       recommendations: null,
       wilderness: false,
       actionsPerHour: 100,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -1123,6 +1141,7 @@ describe('Methods (e2e)', () => {
       wilderness: false,
       members: false,
       actionsPerHour: 100,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 
@@ -1273,6 +1292,7 @@ describe('Methods (e2e)', () => {
       recommendations: null,
       wilderness: false,
       actionsPerHour: 100,
+      actionType: ActionType.ITEMS,
       method: savedMethod,
     });
 


### PR DESCRIPTION
## Summary

- add variant `actionType` support across method variants, snapshots, and API responses
- require complete action metadata on variant write endpoints, including `actionsPerHour` and `actionType`
- cover the new validation and persistence behavior with service and end-to-end tests

## User-facing changelog

- Method variants can now label their action units more clearly, including items, kills, rounds, and chests.
- Creating or editing a method variant now requires action-rate details, preventing incomplete variant data from being saved.

## How to test

```bash
npm run lint
npm test
npm run build
```

Manual check:

1. Apply `sql/2026-08-04-add-variant-action-type.sql` and `sql/2026-08-04-make-variant-actions-per-hour-not-null.sql` in that order.
2. Create or update a method variant through the write endpoints with both `actionsPerHour` and `actionType`, then verify the request succeeds and the response includes `actionType`.
3. Repeat the same requests without `actionsPerHour` and verify the API returns `400`.

## Notes

- Base branch for this PR is `develop`.
- TST deployment must apply the new SQL files in order because the second script makes `actions_per_hour` non-null after backfilling existing rows.
