### PR TITLE
fix: respect explicit roadmap ignored tags

### DIFF
--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -152,7 +152,7 @@ const ROADMAP_EXAMPLE = {
     target_level: 99,
     enabled: true,
     show_only_free_to_play: true,
-    ignoredTags: ['ge_limits', 'not_viable'],
+    ignoredTags: [],
     computedAt: 1771459200,
     usesExactSkillExperience: true,
   },
@@ -402,8 +402,7 @@ export class MethodsController {
   @ApiQuery({
     name: 'ignoredTags',
     required: false,
-    description:
-      'Comma-separated or repeated variant tag keys to ignore. ge_limits and not_viable are always ignored automatically.',
+    description: 'Comma-separated or repeated variant tag keys to ignore.',
   })
   @ApiQuery({
     name: 'enabled',

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -985,7 +985,7 @@ describe('MethodsService variantCount', () => {
     );
   });
 
-  it('builds a fastest roadmap with dynamic skill unlocks and auto-ignored ge_limits and not_viable tags', async () => {
+  it('builds a fastest roadmap with dynamic skill unlocks and forwards only the requested ignored tags', async () => {
     const userRepo = {
       findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
     } as unknown as Repository<User>;
@@ -1142,12 +1142,7 @@ describe('MethodsService variantCount', () => {
       meta: { ignoredTags: string[] };
     };
 
-    expect(findRoadmapCandidatesSpy).toHaveBeenCalledWith(
-      'cooking',
-      true,
-      new Set(['safe', 'ge_limits', 'not_viable']),
-      true,
-    );
+    expect(findRoadmapCandidatesSpy).toHaveBeenCalledWith('cooking', true, new Set(['safe']), true);
     expect(result.data.roadmap.targetLevel).toBe(99);
     expect(result.data.roadmap.ranges.map((range) => range.variant.id)).toEqual(['v1', 'v2', 'v3']);
     expect(result.data.roadmap.ranges.map((range) => [range.levelStart, range.levelEnd])).toEqual([
@@ -1174,9 +1169,7 @@ describe('MethodsService variantCount', () => {
     );
     expect(result.data.roadmap.warnings).toEqual([]);
     expect(result.warnings).toEqual([]);
-    expect(result.meta.ignoredTags).toEqual(
-      expect.arrayContaining(['safe', 'ge_limits', 'not_viable']),
-    );
+    expect(result.meta.ignoredTags).toEqual(['safe']);
   });
 
   it('uses the provided target_level instead of defaulting to 99', async () => {

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -1393,8 +1393,6 @@ export class MethodsService implements OnModuleDestroy {
     const showOnlyFreeToPlay =
       this.parseBooleanQueryParam(query.show_only_free_to_play, 'show_only_free_to_play') ?? false;
     const ignoredTags = new Set(this.parseIgnoredTagsQueryParam(query.ignoredTags) ?? []);
-    ignoredTags.add('ge_limits');
-    ignoredTags.add('not_viable');
 
     const userInfo = await this.fetchRequiredRoadmapUserInfo(username);
     const fallbackLevel = Math.max(


### PR DESCRIPTION
## Summary

- Stop auto-ignoring the `ge_limits` and `not_viable` variant tags when building skill roadmaps.
- Update the roadmap endpoint Swagger example and query parameter description to reflect the new `ignoredTags` behavior.
- Adjust roadmap service tests to assert that only explicitly requested ignored tags are forwarded and returned.

## User-facing changelog

- Roadmap results now respect the exact variant tags you choose to ignore instead of automatically excluding additional tags.

## How to test

```bash
npm run lint
npm test
npm run build
```

- Request the roadmap endpoint with and without `ignoredTags` and confirm that only the provided tags are excluded from results.

## Notes

- Base branch: `develop`.
- This PR is intended for the TST deployment flow.
