### PR TITLE
feat(admin): add presence history reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Available variables:
 - `VARIANT_HISTORY_PRUNE_ENABLED`: Enables hourly pruning of raw and 15m history according to the retention variables.
 - `VARIANT_HISTORY_RAW_RETENTION_HOURS`: Retention for `variant_history` raw points (default `72`).
 - `VARIANT_HISTORY_15M_RETENTION_DAYS`: Retention for `variant_history_15m` rollups (default `90`).
+- `PRESENCE_TTL_SECONDS`: Active heartbeat window in seconds for live presence (default `90`).
+- `PRESENCE_REDIS_KEY`: Redis sorted-set key used for live presence (default `presence:online`).
+- `PRESENCE_HOUR_PEAK_REDIS_PREFIX`: Prefix for hourly peak accumulators in Redis (default `presence:peak:hour:`).
+- `PRESENCE_HOUR_PEAK_TTL_HOURS`: Safety TTL for hourly peak accumulators before persistence (default `96`).
 - `CORS_ORIGINS`: Comma-separated allowed origins (e.g. `https://example.com,https://app.example.com`).
 - `SWAGGER_ENABLED`: Set to `true` to enable Swagger in production (disabled by default in prod).
 - `CDN_BASE`: Base URL for item icons (defaults to OSRS Wiki).
@@ -177,6 +181,26 @@ npm run sync:items:mapping -- --chunkSize=1000
 ## SQL setup for `public.users`
 
 This repository does not include TypeORM migrations yet, so create the table manually in Railway/Postgres:
+
+## Manual SQL setup for `presence_history`
+
+This repository still does not ship automated database migrations between TST and PRO.
+
+Before deploying the presence-history backend changes, execute the versioned SQL file below once in each database:
+
+```txt
+database/sql/create_presence_history.sql
+```
+
+Presence history jobs:
+
+- Hour finalizer: minute `1` every hour in `UTC`
+- Daily rollup: `00:05 UTC`
+- Daily cleanup: immediately after a successful daily rollup
+
+Admin history endpoint:
+
+- `GET /admin/presence/history?range=72h|30d|1y`
 
 ```sql
 CREATE TABLE IF NOT EXISTS public.users (

--- a/database/sql/create_presence_history.sql
+++ b/database/sql/create_presence_history.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS public.presence_history (
+  bucket_kind text NOT NULL,
+  bucket_start timestamptz NOT NULL,
+  peak_online integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT presence_history_pk PRIMARY KEY (bucket_kind, bucket_start),
+  CONSTRAINT presence_history_bucket_kind_check
+    CHECK (bucket_kind IN ('hour', 'day')),
+  CONSTRAINT presence_history_peak_online_check
+    CHECK (peak_online >= 0),
+  CONSTRAINT presence_history_bucket_alignment_check
+    CHECK (
+      (bucket_kind = 'hour' AND bucket_start = date_trunc('hour', bucket_start))
+      OR
+      (bucket_kind = 'day' AND bucket_start = date_trunc('day', bucket_start))
+    )
+);

--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -3,6 +3,7 @@ import { GUARDS_METADATA } from '@nestjs/common/constants';
 import type { Request } from 'express';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { PresenceHistoryRange } from '../presence/dto/presence-history-query.dto';
 import { AdminController } from './admin.controller';
 import type { AdminService } from './admin.service';
 
@@ -30,6 +31,17 @@ describe('AdminController', () => {
       { source: 'mapping', dryRun: true },
       'user-1',
     );
+  });
+
+  it('forwards admin presence history requests', async () => {
+    const service: { getPresenceHistory: jest.Mock } = {
+      getPresenceHistory: jest.fn().mockResolvedValue({ data: { points: [] } }),
+    };
+    const controller = new AdminController(service as unknown as AdminService);
+
+    await controller.getPresenceHistory({ range: PresenceHistoryRange.RANGE_72H });
+
+    expect(service.getPresenceHistory).toHaveBeenCalledWith(PresenceHistoryRange.RANGE_72H);
   });
 
   it('keeps quest sync as an explicit placeholder', () => {

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -21,6 +21,10 @@ import type { Request } from 'express';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import {
+  PresenceHistoryQueryDto,
+  PresenceHistoryRange,
+} from '../presence/dto/presence-history-query.dto';
 import { AdminService } from './admin.service';
 import { SyncItemsDto } from './dto/sync-items.dto';
 
@@ -48,6 +52,7 @@ export class AdminController {
             usersRegistered: 10,
             items: 4200,
             quests: 165,
+            activeSessions: 17,
             methods: { total: 50, enabled: 48, disabled: 2 },
             variants: { total: 90, enabled: 85, disabled: 5 },
             enabledMethodVariantsBySkill: [
@@ -81,6 +86,43 @@ export class AdminController {
   @ApiForbiddenResponse({ description: 'Only super_admin can perform this action' })
   async getOverview() {
     return this.adminService.getOverview();
+  }
+
+  @Get('presence/history')
+  @ApiOperation({
+    summary: 'Get concurrent users history',
+    description:
+      'Returns zero-filled concurrent-user history for admin charts. The 72h range includes the current UTC hour as a provisional point sourced from Redis.',
+  })
+  @ApiQuery({
+    name: 'range',
+    required: true,
+    enum: PresenceHistoryRange,
+    description: 'History range to load',
+  })
+  @ApiOkResponse({
+    description: 'Concurrent users history',
+    schema: {
+      example: {
+        data: {
+          range: '72h',
+          granularity: 'hour',
+          timezone: 'UTC',
+          points: [
+            {
+              bucketStart: '2026-08-05T14:00:00.000Z',
+              peakOnline: 17,
+              provisional: false,
+            },
+          ],
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired bearer token' })
+  @ApiForbiddenResponse({ description: 'Only super_admin can perform this action' })
+  async getPresenceHistory(@Query() query: PresenceHistoryQueryDto) {
+    return this.adminService.getPresenceHistory(query.range);
   }
 
   @Get('jobs')

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -8,6 +8,7 @@ import { Item } from '../items/entities/item.entity';
 import { MethodProfitRefresherModule } from '../method-profit-refresher/method-profit-refresher.module';
 import { Method } from '../methods/entities/method.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
+import { PresenceModule } from '../presence/presence.module';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { AdminScriptExecution } from './entities/admin-script-execution.entity';
@@ -18,6 +19,7 @@ import { AdminScriptExecution } from './entities/admin-script-execution.entity';
     AuthModule,
     ItemsModule,
     MethodProfitRefresherModule,
+    PresenceModule,
   ],
   controllers: [AdminController],
   providers: [AdminService],

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -9,6 +9,8 @@ import { Quest } from '../catalogs/entities/quest.entity';
 import { Method } from '../methods/entities/method.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
 import type { MethodProfitRefresherService } from '../method-profit-refresher/method-profit-refresher.service';
+import { PresenceHistoryRange } from '../presence/dto/presence-history-query.dto';
+import type { PresenceService } from '../presence/presence.service';
 import { AdminService } from './admin.service';
 import { AdminScriptExecution } from './entities/admin-script-execution.entity';
 
@@ -78,6 +80,15 @@ describe('AdminService', () => {
       }),
     };
     const profitRefresher = { refresh: jest.fn().mockResolvedValue(undefined) };
+    const presenceService = {
+      getOnlineCount: jest.fn().mockResolvedValue(17),
+      getPresenceHistory: jest.fn().mockResolvedValue({
+        range: PresenceHistoryRange.RANGE_72H,
+        granularity: 'hour',
+        timezone: 'UTC',
+        points: [],
+      }),
+    };
     const config = {
       get: jest.fn((key: string) =>
         key === 'CDN_BASE' ? 'https://oldschool.runescape.wiki/images/' : undefined,
@@ -94,6 +105,7 @@ describe('AdminService', () => {
       mappingSync as unknown as ItemsMappingSyncService,
       wikiSync as unknown as ItemsWikiSyncService,
       profitRefresher as unknown as MethodProfitRefresherService,
+      presenceService as unknown as PresenceService,
       config as unknown as ConfigService,
     );
 
@@ -104,6 +116,7 @@ describe('AdminService', () => {
       variantRepo,
       itemRepo,
       questRepo,
+      presenceService,
     };
   }
 
@@ -125,6 +138,7 @@ describe('AdminService', () => {
       enabled: 2,
       disabled: 1,
     });
+    expect(response.data.counts.activeSessions).toBe(17);
     expect(response.data.counts.enabledMethodVariantsBySkill).toEqual([
       { skill: 'Cooking', variants: 2 },
       { skill: 'Magic', variants: 1 },
@@ -147,6 +161,31 @@ describe('AdminService', () => {
           addedAt: '2026-02-11T21:32:13.214Z',
         },
       ],
+    });
+  });
+
+  it('returns activeSessions as null when redis presence lookup fails', async () => {
+    const { service, presenceService } = createService();
+    presenceService.getOnlineCount.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    const response = await service.getOverview();
+
+    expect(response.data.counts.activeSessions).toBeNull();
+  });
+
+  it('forwards presence history queries to the presence service', async () => {
+    const { service, presenceService } = createService();
+
+    const response = await service.getPresenceHistory(PresenceHistoryRange.RANGE_30D);
+
+    expect(presenceService.getPresenceHistory).toHaveBeenCalledWith(PresenceHistoryRange.RANGE_30D);
+    expect(response).toEqual({
+      data: {
+        range: PresenceHistoryRange.RANGE_72H,
+        granularity: 'hour',
+        timezone: 'UTC',
+        points: [],
+      },
     });
   });
 

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -11,6 +11,8 @@ import { Method } from '../methods/entities/method.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
 import { MethodProfitRefresherService } from '../method-profit-refresher/method-profit-refresher.service';
 import { ADMIN_SCRIPT_NAME_MAX_LENGTH } from '../methods/dto/validation.constants';
+import { PresenceHistoryRange } from '../presence/dto/presence-history-query.dto';
+import { PresenceService } from '../presence/presence.service';
 import { SyncItemsDto } from './dto/sync-items.dto';
 import { AdminScriptExecution } from './entities/admin-script-execution.entity';
 
@@ -36,6 +38,7 @@ export class AdminService {
     private readonly itemsMappingSyncService: ItemsMappingSyncService,
     private readonly itemsWikiSyncService: ItemsWikiSyncService,
     private readonly methodProfitRefresherService: MethodProfitRefresherService,
+    private readonly presenceService: PresenceService,
     private readonly config: ConfigService,
   ) {}
 
@@ -52,6 +55,7 @@ export class AdminService {
       latestExecutions,
       latestItems,
       latestQuests,
+      activeSessions,
     ] = await Promise.all([
       this.userRepo.count(),
       this.itemRepo.count(),
@@ -64,6 +68,7 @@ export class AdminService {
       this.getLatestExecutionsByScript(),
       this.getLatestItems(),
       this.getLatestQuests(),
+      this.getActiveSessionsSafe(),
     ]);
 
     return {
@@ -72,6 +77,7 @@ export class AdminService {
           usersRegistered,
           items,
           quests,
+          activeSessions,
           methods: {
             total: methodsTotal,
             enabled: methodsEnabled,
@@ -86,6 +92,12 @@ export class AdminService {
           quests: latestQuests,
         },
       },
+    };
+  }
+
+  async getPresenceHistory(range: PresenceHistoryRange) {
+    return {
+      data: await this.presenceService.getPresenceHistory(range),
     };
   }
 
@@ -296,6 +308,14 @@ export class AdminService {
       slug: row.slug,
       addedAt: new Date(row.created_at).toISOString(),
     }));
+  }
+
+  private async getActiveSessionsSafe(): Promise<number | null> {
+    try {
+      return await this.presenceService.getOnlineCount();
+    } catch {
+      return null;
+    }
   }
 
   private async runScript(

--- a/src/presence/dto/presence-history-query.dto.ts
+++ b/src/presence/dto/presence-history-query.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+
+export enum PresenceHistoryRange {
+  RANGE_72H = '72h',
+  RANGE_30D = '30d',
+  RANGE_1Y = '1y',
+}
+
+export class PresenceHistoryQueryDto {
+  @ApiProperty({
+    enum: PresenceHistoryRange,
+    description: 'History window to return for concurrent users.',
+    example: PresenceHistoryRange.RANGE_72H,
+  })
+  @IsEnum(PresenceHistoryRange)
+  range: PresenceHistoryRange;
+}

--- a/src/presence/entities/presence-history.entity.ts
+++ b/src/presence/entities/presence-history.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+export type PresenceHistoryBucketKind = 'hour' | 'day';
+
+@Entity('presence_history')
+export class PresenceHistory {
+  @PrimaryColumn({ name: 'bucket_kind', type: 'text' })
+  bucketKind: PresenceHistoryBucketKind;
+
+  @PrimaryColumn({ name: 'bucket_start', type: 'timestamptz' })
+  bucketStart: Date;
+
+  @Column({ name: 'peak_online', type: 'int' })
+  peakOnline: number;
+
+  @Column({ name: 'created_at', type: 'timestamptz', default: () => 'now()' })
+  createdAt: Date;
+
+  @Column({ name: 'updated_at', type: 'timestamptz', default: () => 'now()' })
+  updatedAt: Date;
+}

--- a/src/presence/presence.module.ts
+++ b/src/presence/presence.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { PresenceController } from './presence.controller';
+import { PresenceHistory } from './entities/presence-history.entity';
 import { PresenceService } from './presence.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, TypeOrmModule.forFeature([PresenceHistory])],
   controllers: [PresenceController],
   providers: [PresenceService],
   exports: [PresenceService],

--- a/src/presence/presence.service.spec.ts
+++ b/src/presence/presence.service.spec.ts
@@ -1,6 +1,8 @@
 import { Logger } from '@nestjs/common';
-import { BadRequestException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
+import type { Repository } from 'typeorm';
+import { PresenceHistoryRange } from './dto/presence-history-query.dto';
+import { PresenceHistory } from './entities/presence-history.entity';
 import { PresenceService } from './presence.service';
 
 const createConfigService = (env: Record<string, string | undefined> = {}): ConfigService =>
@@ -15,90 +17,95 @@ const createRedisMock = () => {
 
   const pipeline = {
     zremrangebyscore: jest.fn().mockReturnThis(),
-    zadd: jest.fn().mockReturnThis(),
     zcount: jest.fn().mockReturnThis(),
     exec: jest.fn().mockImplementation(() => Promise.resolve(pipelineState.results)),
   };
 
   const redis = {
+    eval: jest.fn(),
     pipeline: jest.fn(() => pipeline),
     zremrangebyscore: jest.fn(),
+    set: jest.fn().mockResolvedValue('OK'),
+    get: jest.fn().mockResolvedValue(null),
+    del: jest.fn().mockResolvedValue(1),
   };
 
   return { redis, pipeline, pipelineState };
 };
 
+const createDeleteBuilder = (result: { affected?: number }) => ({
+  delete: jest.fn().mockReturnThis(),
+  from: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  execute: jest.fn().mockResolvedValue(result),
+});
+
 describe('PresenceService', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   const createService = (
     env: Record<string, string | undefined> = {},
     redisOverride?: ReturnType<typeof createRedisMock>['redis'],
+    repoOverride?: Partial<Repository<PresenceHistory>>,
   ) => {
     const redisMock = redisOverride ?? createRedisMock().redis;
     const redisService = {
       getClient: jest.fn().mockReturnValue(redisMock),
     };
+    const defaultHourDeleteBuilder = createDeleteBuilder({ affected: 0 });
+    const defaultDayDeleteBuilder = createDeleteBuilder({ affected: 0 });
+    const presenceHistoryRepo = {
+      query: jest.fn().mockResolvedValue([]),
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValueOnce(defaultHourDeleteBuilder)
+        .mockReturnValueOnce(defaultDayDeleteBuilder),
+      ...repoOverride,
+    };
 
-    const service = new PresenceService(createConfigService(env), redisService as never);
+    const service = new PresenceService(
+      createConfigService(env),
+      redisService as never,
+      presenceHistoryRepo as unknown as Repository<PresenceHistory>,
+    );
 
-    return { service, redisMock, redisService };
+    return {
+      service,
+      redisMock,
+      redisService,
+      presenceHistoryRepo,
+      defaultHourDeleteBuilder,
+      defaultDayDeleteBuilder,
+    };
   };
 
-  it('registers an anonymous visitor heartbeat and returns the online count', async () => {
-    const { redis, pipeline, pipelineState } = createRedisMock();
-    pipelineState.results = [
-      [null, 0],
-      [null, 1],
-      [null, 127],
-    ];
+  it('registers a heartbeat through a single Lua script and returns the online count', async () => {
+    const { redis } = createRedisMock();
+    redis.eval.mockResolvedValue(127);
     const { service } = createService({}, redis);
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(new Date('2026-08-05T14:33:10.000Z').getTime());
 
-    const online = await service.recordHeartbeat({
-      visitorId: '550e8400-e29b-41d4-a716-446655440000',
-    });
+    const online = await service.recordHeartbeat({ visitorId: 'visitor-123' });
 
-    expect(redis.pipeline).toHaveBeenCalledTimes(1);
-    expect(pipeline.zremrangebyscore).toHaveBeenCalledWith(
-      'presence:online',
-      '-inf',
-      expect.stringMatching(/^\(\d+$/),
-    );
-    expect(pipeline.zadd).toHaveBeenCalledWith(
-      'presence:online',
-      expect.any(Number),
-      'visitor:550e8400-e29b-41d4-a716-446655440000',
-    );
-    expect(pipeline.zcount).toHaveBeenCalledWith('presence:online', expect.any(Number), '+inf');
-    expect(online).toBe(127);
-  });
-
-  it('updates the same anonymous visitor without changing the member identity', async () => {
-    const { redis, pipeline, pipelineState } = createRedisMock();
-    pipelineState.results = [
-      [null, 0],
-      [null, 1],
-      [null, 1],
-    ];
-    const { service } = createService({}, redis);
-
-    await service.recordHeartbeat({ visitorId: 'same-visitor' });
-    await service.recordHeartbeat({ visitorId: 'same-visitor' });
-
-    expect(pipeline.zadd).toHaveBeenNthCalledWith(
-      1,
-      'presence:online',
-      expect.any(Number),
-      'visitor:same-visitor',
-    );
-    expect(pipeline.zadd).toHaveBeenNthCalledWith(
+    expect(redis.eval).toHaveBeenCalledTimes(1);
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('ZCOUNT'"),
       2,
       'presence:online',
-      expect.any(Number),
-      'visitor:same-visitor',
+      'presence:peak:hour:2026-08-05T14:00:00.000Z',
+      expect.any(String),
+      expect.any(String),
+      'visitor:visitor-123',
+      String(96 * 60 * 60 * 1000),
     );
+    expect(online).toBe(127);
+    nowSpy.mockRestore();
   });
 
   it('counts online users while excluding expired entries', async () => {
@@ -118,84 +125,232 @@ describe('PresenceService', () => {
     nowSpy.mockRestore();
   });
 
-  it('cleans up expired presences', async () => {
+  it('finalizes the last 72 closed hours, stores zeros for gaps, and only deletes persisted redis keys', async () => {
     const { redis } = createRedisMock();
-    redis.zremrangebyscore = jest.fn().mockResolvedValue(9);
-    const { service } = createService({}, redis);
-
-    const removed = await service.pruneExpiredPresence(250_000);
-
-    expect(redis.zremrangebyscore).toHaveBeenCalledWith('presence:online', '-inf', '(160000');
-    expect(removed).toBe(9);
-  });
-
-  it('rejects a heartbeat without visitorId when there is no authenticated user', async () => {
-    const { service } = createService();
-
-    await expect(service.recordHeartbeat({})).rejects.toBeInstanceOf(BadRequestException);
-  });
-
-  it('prioritizes the authenticated user id over visitorId when both are present', async () => {
-    const { redis, pipeline, pipelineState } = createRedisMock();
-    pipelineState.results = [
-      [null, 0],
-      [null, 1],
-      [null, 7],
-    ];
-    const { service } = createService({}, redis);
-
-    const online = await service.recordHeartbeat({
-      authenticatedUserId: 'user-123',
-      visitorId: 'visitor-123',
+    redis.get.mockImplementation((key: string) => {
+      if (key === 'presence:peak:hour:2026-08-02T15:00:00.000Z') return '5';
+      if (key === 'presence:peak:hour:2026-08-05T14:00:00.000Z') return '17';
+      return null;
     });
+    const repo = {
+      query: jest.fn().mockResolvedValue([]),
+    };
+    const { service } = createService({}, redis, repo);
 
-    expect(pipeline.zadd).toHaveBeenCalledWith(
-      'presence:online',
-      expect.any(Number),
-      'user:user-123',
+    await service.finalizeHourlyHistory(new Date('2026-08-05T15:10:00.000Z'));
+
+    expect(redis.set).toHaveBeenCalledWith(
+      'lock:presence:history:hourly-finalizer',
+      expect.any(String),
+      'PX',
+      120_000,
+      'NX',
     );
-    expect(online).toBe(7);
+    expect(repo.query).toHaveBeenCalledWith(expect.stringContaining('GREATEST'), [
+      'hour',
+      '2026-08-02T15:00:00.000Z',
+      5,
+    ]);
+    expect(repo.query).toHaveBeenCalledWith(expect.stringContaining('GREATEST'), [
+      'hour',
+      '2026-08-02T16:00:00.000Z',
+      0,
+    ]);
+    expect(repo.query).toHaveBeenCalledWith(expect.stringContaining('GREATEST'), [
+      'hour',
+      '2026-08-05T14:00:00.000Z',
+      17,
+    ]);
+    expect(redis.del).toHaveBeenCalledWith('presence:peak:hour:2026-08-02T15:00:00.000Z');
+    expect(redis.del).toHaveBeenCalledWith('presence:peak:hour:2026-08-05T14:00:00.000Z');
+    expect(redis.del).not.toHaveBeenCalledWith('presence:peak:hour:2026-08-02T16:00:00.000Z');
+    expect(redis.eval).toHaveBeenLastCalledWith(
+      expect.stringContaining("redis.call('get', KEYS[1])"),
+      1,
+      'lock:presence:history:hourly-finalizer',
+      expect.any(String),
+    );
   });
 
-  it('logs and rethrows Redis errors during heartbeat operations', async () => {
-    const { redis, pipeline } = createRedisMock();
+  it('skips hourly finalization when the redis lock is already held', async () => {
+    const { redis } = createRedisMock();
+    redis.set.mockResolvedValue(null);
+    const repo = {
+      query: jest.fn().mockResolvedValue([]),
+    };
+    const { service } = createService({}, redis, repo);
+
+    await service.finalizeHourlyHistory(new Date('2026-08-05T15:10:00.000Z'));
+
+    expect(repo.query).not.toHaveBeenCalled();
+    expect(redis.get).not.toHaveBeenCalled();
+  });
+
+  it('rolls up the previous UTC day with GREATEST and runs cleanup only after success', async () => {
+    const { redis } = createRedisMock();
+    const repo = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ peak_online: '17' }])
+        .mockResolvedValueOnce([]),
+    };
+    const { service } = createService({}, redis, repo);
+    const privateService = service as unknown as {
+      cleanupHistory: (
+        referenceDate?: Date,
+      ) => Promise<{ dayDeleted: number; hourDeleted: number }>;
+    };
+    const cleanupSpy = jest
+      .spyOn(privateService, 'cleanupHistory')
+      .mockResolvedValue({ dayDeleted: 1, hourDeleted: 2 });
+
+    await service.rollupDailyHistory(new Date('2026-08-06T00:05:00.000Z'));
+
+    expect(repo.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('COALESCE(MAX(peak_online), 0)'),
+      ['2026-08-05T00:00:00.000Z', '2026-08-06T00:00:00.000Z'],
+    );
+    expect(repo.query).toHaveBeenNthCalledWith(2, expect.stringContaining('GREATEST'), [
+      'day',
+      '2026-08-05T00:00:00.000Z',
+      17,
+    ]);
+    expect(cleanupSpy).toHaveBeenCalledWith(new Date('2026-08-06T00:05:00.000Z'));
+  });
+
+  it('does not run cleanup when the daily rollup upsert fails', async () => {
+    const { redis } = createRedisMock();
+    const repo = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ peak_online: '11' }])
+        .mockRejectedValueOnce(new Error('db down')),
+    };
+    const { service } = createService({}, redis, repo);
+    const privateService = service as unknown as {
+      cleanupHistory: (
+        referenceDate?: Date,
+      ) => Promise<{ dayDeleted: number; hourDeleted: number }>;
+    };
+    const cleanupSpy = jest
+      .spyOn(privateService, 'cleanupHistory')
+      .mockResolvedValue({ dayDeleted: 0, hourDeleted: 0 });
+
+    await expect(service.rollupDailyHistory(new Date('2026-08-06T00:05:00.000Z'))).rejects.toThrow(
+      'db down',
+    );
+    expect(cleanupSpy).not.toHaveBeenCalled();
+  });
+
+  it('applies hourly and daily retention boundaries during cleanup', async () => {
+    const { redis } = createRedisMock();
+    const hourDeleteBuilder = createDeleteBuilder({ affected: 4 });
+    const dayDeleteBuilder = createDeleteBuilder({ affected: 2 });
+    const repo = {
+      query: jest.fn().mockResolvedValue([]),
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValueOnce(hourDeleteBuilder)
+        .mockReturnValueOnce(dayDeleteBuilder),
+    };
+    const { service } = createService({}, redis, repo);
+
+    const privateService = service as unknown as {
+      cleanupHistory: (
+        referenceDate?: Date,
+      ) => Promise<{ dayDeleted: number; hourDeleted: number }>;
+    };
+    const result = await privateService.cleanupHistory(new Date('2026-08-06T00:05:00.000Z'));
+
+    expect(hourDeleteBuilder.andWhere).toHaveBeenCalledWith('bucket_start < :boundary', {
+      boundary: '2026-08-03T00:00:00.000Z',
+    });
+    expect(dayDeleteBuilder.andWhere).toHaveBeenCalledWith('bucket_start < :boundary', {
+      boundary: '2023-08-06T00:00:00.000Z',
+    });
+    expect(result).toEqual({ dayDeleted: 2, hourDeleted: 4 });
+  });
+
+  it('returns exactly 72 hourly points with zero fill and the current provisional bucket', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-05T15:23:00.000Z'));
+    const { redis } = createRedisMock();
+    redis.get.mockResolvedValue('9');
+    const repo = {
+      query: jest.fn().mockResolvedValue([
+        { bucket_start: '2026-08-05T13:00:00.000Z', peak_online: 4 },
+        { bucket_start: '2026-08-05T14:00:00.000Z', peak_online: 17 },
+      ]),
+    };
+    const { service } = createService({}, redis, repo);
+
+    const result = await service.getPresenceHistory(PresenceHistoryRange.RANGE_72H);
+
+    expect(result.granularity).toBe('hour');
+    expect(result.points).toHaveLength(72);
+    expect(result.points[0]).toEqual({
+      bucketStart: '2026-08-02T16:00:00.000Z',
+      peakOnline: 0,
+      provisional: false,
+    });
+    expect(result.points[69]).toEqual({
+      bucketStart: '2026-08-05T13:00:00.000Z',
+      peakOnline: 4,
+      provisional: false,
+    });
+    expect(result.points[70]).toEqual({
+      bucketStart: '2026-08-05T14:00:00.000Z',
+      peakOnline: 17,
+      provisional: false,
+    });
+    expect(result.points[71]).toEqual({
+      bucketStart: '2026-08-05T15:00:00.000Z',
+      peakOnline: 9,
+      provisional: true,
+    });
+  });
+
+  it('returns finalized daily history for 30d with zero fill', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-05T15:23:00.000Z'));
+    const { redis } = createRedisMock();
+    const repo = {
+      query: jest.fn().mockResolvedValue([
+        { bucket_start: '2026-07-10T00:00:00.000Z', peak_online: 8 },
+        { bucket_start: '2026-08-04T00:00:00.000Z', peak_online: 19 },
+      ]),
+    };
+    const { service } = createService({}, redis, repo);
+
+    const result = await service.getPresenceHistory(PresenceHistoryRange.RANGE_30D);
+
+    expect(result.granularity).toBe('day');
+    expect(result.points).toHaveLength(30);
+    expect(result.points[0]).toEqual({
+      bucketStart: '2026-07-06T00:00:00.000Z',
+      peakOnline: 0,
+      provisional: false,
+    });
+    expect(result.points[4]).toEqual({
+      bucketStart: '2026-07-10T00:00:00.000Z',
+      peakOnline: 8,
+      provisional: false,
+    });
+    expect(result.points[29]).toEqual({
+      bucketStart: '2026-08-04T00:00:00.000Z',
+      peakOnline: 19,
+      provisional: false,
+    });
+  });
+
+  it('logs and rethrows redis errors during heartbeat operations', async () => {
+    const { redis } = createRedisMock();
     const redisError = new Error('redis down');
-    pipeline.exec.mockRejectedValue(redisError);
+    redis.eval.mockRejectedValue(redisError);
     const { service } = createService({}, redis);
     const logger = (service as unknown as { logger: Logger }).logger;
     const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
 
     await expect(service.recordHeartbeat({ visitorId: 'visitor-1' })).rejects.toThrow('redis down');
     expect(loggerSpy).toHaveBeenCalledWith('Presence heartbeat failed', redisError.stack);
-  });
-
-  it('does not expose identifiers in the heartbeat result', async () => {
-    const { redis, pipelineState } = createRedisMock();
-    pipelineState.results = [
-      [null, 0],
-      [null, 1],
-      [null, 5],
-    ];
-    const { service } = createService({}, redis);
-
-    const result = await service.recordHeartbeat({ visitorId: 'visitor-1' });
-
-    expect(result).toBe(5);
-    expect((result as unknown as Record<string, unknown>).visitorId).toBeUndefined();
-  });
-
-  it('logs cron prune errors without throwing', async () => {
-    const { service } = createService();
-    const logger = (service as unknown as { logger: Logger }).logger;
-    const loggerSpy = jest.spyOn(logger, 'error').mockImplementation();
-    jest
-      .spyOn(service, 'pruneExpiredPresence')
-      .mockRejectedValue(new Error('temporary redis failure'));
-
-    await expect(service.handlePresencePruneCron()).resolves.toBeUndefined();
-    expect(loggerSpy).toHaveBeenCalledWith(
-      'Presence prune cron failed',
-      expect.stringContaining('temporary redis failure'),
-    );
   });
 });

--- a/src/presence/presence.service.ts
+++ b/src/presence/presence.service.ts
@@ -1,12 +1,38 @@
-import { BadRequestException, Injectable, Logger, Optional } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
-import IORedis, { Redis } from 'ioredis';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { Redis } from 'ioredis';
+import { Repository } from 'typeorm';
+import { parseBooleanEnv } from '../common/utils/parse-boolean-env';
 import { RedisService } from '../redis/redis.service';
+import { PresenceHistoryRange } from './dto/presence-history-query.dto';
+import {
+  PresenceHistory,
+  type PresenceHistoryBucketKind,
+} from './entities/presence-history.entity';
 
 interface PresenceIdentity {
   authenticatedUserId?: string | null;
   visitorId?: string;
+}
+
+export interface PresenceHistoryPoint {
+  bucketStart: string;
+  peakOnline: number;
+  provisional: boolean;
+}
+
+export interface PresenceHistoryResponse {
+  range: PresenceHistoryRange;
+  granularity: 'hour' | 'day';
+  timezone: 'UTC';
+  points: PresenceHistoryPoint[];
+}
+
+interface CleanupStats {
+  dayDeleted: number;
+  hourDeleted: number;
 }
 
 @Injectable()
@@ -15,35 +41,77 @@ export class PresenceService {
   private readonly redis: Redis;
   private readonly presenceTtlSeconds: number;
   private readonly presenceRedisKey: string;
+  private readonly hourPeakKeyPrefix: string;
+  private readonly hourPeakTtlMs: number;
+  private readonly jobsEnabled: boolean;
+  private readonly pruneLockKey = 'lock:presence:history:hourly-finalizer';
+  private readonly dailyRollupLockKey = 'lock:presence:history:daily-rollup';
+  private readonly pruneLockTtlMs = 120_000;
+  private readonly dailyRollupLockTtlMs = 300_000;
+  private readonly recordHeartbeatScript = `
+    redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', '(' .. ARGV[1])
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+    local online = tonumber(redis.call('ZCOUNT', KEYS[1], ARGV[1], '+inf'))
+    local currentPeak = tonumber(redis.call('GET', KEYS[2]) or '-1')
+
+    if online > currentPeak then
+      redis.call('SET', KEYS[2], online, 'PX', ARGV[4])
+    else
+      redis.call('PEXPIRE', KEYS[2], ARGV[4])
+    end
+
+    return online
+  `;
+  private readonly releaseLockScript = `
+    if redis.call('get', KEYS[1]) == ARGV[1] then
+      return redis.call('del', KEYS[1])
+    end
+    return 0
+  `;
 
   constructor(
     private readonly config: ConfigService,
-    @Optional() redisService?: RedisService,
+    private readonly redisService: RedisService,
+    @InjectRepository(PresenceHistory)
+    private readonly presenceHistoryRepo: Repository<PresenceHistory>,
   ) {
-    this.redis =
-      redisService?.getClient() ??
-      new IORedis((this.config.get<string>('REDIS_URL') as string) ?? '');
+    this.redis = this.redisService.getClient();
     this.presenceTtlSeconds = this.parsePositiveIntEnv(
       this.config.get<string>('PRESENCE_TTL_SECONDS'),
       90,
     );
     this.presenceRedisKey =
       this.config.get<string>('PRESENCE_REDIS_KEY')?.trim() || 'presence:online';
+    this.hourPeakKeyPrefix =
+      this.config.get<string>('PRESENCE_HOUR_PEAK_REDIS_PREFIX')?.trim() || 'presence:peak:hour:';
+    this.hourPeakTtlMs =
+      this.parsePositiveIntEnv(this.config.get<string>('PRESENCE_HOUR_PEAK_TTL_HOURS'), 96) *
+      60 *
+      60 *
+      1000;
+    this.jobsEnabled = parseBooleanEnv(this.config.get<string>('SCHEDULED_JOBS_ENABLED'), true);
   }
 
   async recordHeartbeat(identity: PresenceIdentity): Promise<number> {
     const member = this.resolveMember(identity);
-    const nowMs = Date.now();
+    const now = new Date();
+    const nowMs = now.getTime();
     const cutoffMs = this.getCutoffMs(nowMs);
+    const hourStart = this.startOfUtcHour(now);
+    const hourPeakKey = this.buildHourPeakKey(hourStart);
 
     try {
-      const pipeline = this.redis.pipeline();
-      pipeline.zremrangebyscore(this.presenceRedisKey, '-inf', `(${cutoffMs}`);
-      pipeline.zadd(this.presenceRedisKey, nowMs, member);
-      pipeline.zcount(this.presenceRedisKey, cutoffMs, '+inf');
-
-      const results = await pipeline.exec();
-      return this.readIntegerResult(results, 2, 'heartbeat count');
+      const result = await this.redis.eval(
+        this.recordHeartbeatScript,
+        2,
+        this.presenceRedisKey,
+        hourPeakKey,
+        String(cutoffMs),
+        String(nowMs),
+        member,
+        String(this.hourPeakTtlMs),
+      );
+      return this.toInteger(result, 'heartbeat count');
     } catch (error) {
       this.logRedisError('heartbeat', error);
       throw error;
@@ -67,13 +135,64 @@ export class PresenceService {
     }
   }
 
+  async getPresenceHistory(range: PresenceHistoryRange): Promise<PresenceHistoryResponse> {
+    if (range === PresenceHistoryRange.RANGE_72H) {
+      return {
+        range,
+        granularity: 'hour',
+        timezone: 'UTC',
+        points: await this.getHourlyPresenceHistory(),
+      };
+    }
+
+    const days = range === PresenceHistoryRange.RANGE_30D ? 30 : 365;
+    return {
+      range,
+      granularity: 'day',
+      timezone: 'UTC',
+      points: await this.getDailyPresenceHistory(days),
+    };
+  }
+
   @Cron('*/10 * * * *')
   async handlePresencePruneCron(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
     try {
       await this.pruneExpiredPresence();
     } catch (error) {
       const stack = error instanceof Error ? error.stack : undefined;
       this.logger.error('Presence prune cron failed', stack);
+    }
+  }
+
+  @Cron('1 * * * *', { timeZone: 'UTC' })
+  async handleHourlyHistoryFinalizerCron(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
+    try {
+      await this.finalizeHourlyHistory();
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error('Presence hourly finalizer cron failed', stack);
+    }
+  }
+
+  @Cron('5 0 * * *', { timeZone: 'UTC' })
+  async handleDailyHistoryRollupCron(): Promise<void> {
+    if (!this.jobsEnabled) {
+      return;
+    }
+
+    try {
+      await this.rollupDailyHistory();
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error('Presence daily rollup cron failed', stack);
     }
   }
 
@@ -93,6 +212,251 @@ export class PresenceService {
     }
   }
 
+  async finalizeHourlyHistory(referenceDate = new Date()): Promise<void> {
+    const startedAt = Date.now();
+    const lockValue = await this.acquireLock(this.pruneLockKey, this.pruneLockTtlMs);
+    if (!lockValue) {
+      this.logger.log(
+        `hourly finalizer skipped reason=lock_not_acquired durationMs=${Date.now() - startedAt}`,
+      );
+      return;
+    }
+
+    try {
+      const currentHourStart = this.startOfUtcHour(referenceDate);
+      const earliestHour = this.addHours(currentHourStart, -72);
+      const lastClosedHour = this.addHours(currentHourStart, -1);
+      let processed = 0;
+
+      for (
+        let cursor = earliestHour;
+        cursor.getTime() <= lastClosedHour.getTime();
+        cursor = this.addHours(cursor, 1)
+      ) {
+        const peakKey = this.buildHourPeakKey(cursor);
+        const rawPeak = await this.redis.get(peakKey);
+        const peakOnline = rawPeak === null ? 0 : this.toInteger(rawPeak, 'hourly peak');
+
+        await this.upsertHistoryBucket('hour', cursor, peakOnline);
+        if (rawPeak !== null) {
+          await this.redis.del(peakKey);
+        }
+
+        processed += 1;
+      }
+
+      this.logger.log(
+        `hourly finalizer completed durationMs=${Date.now() - startedAt} processed=${processed}`,
+      );
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`hourly finalizer failed durationMs=${Date.now() - startedAt}`, stack);
+      throw error;
+    } finally {
+      await this.releaseLock(this.pruneLockKey, lockValue);
+    }
+  }
+
+  async rollupDailyHistory(referenceDate = new Date()): Promise<void> {
+    const startedAt = Date.now();
+    const lockValue = await this.acquireLock(this.dailyRollupLockKey, this.dailyRollupLockTtlMs);
+    if (!lockValue) {
+      this.logger.log(
+        `daily rollup skipped reason=lock_not_acquired durationMs=${Date.now() - startedAt}`,
+      );
+      return;
+    }
+
+    try {
+      const currentDayStart = this.startOfUtcDay(referenceDate);
+      const previousDayStart = this.addDays(currentDayStart, -1);
+      const peakOnline = await this.findDailyPeak(previousDayStart, currentDayStart);
+
+      await this.upsertHistoryBucket('day', previousDayStart, peakOnline);
+      const cleanup = await this.cleanupHistory(referenceDate);
+
+      this.logger.log(
+        `daily rollup completed durationMs=${Date.now() - startedAt} day=${previousDayStart.toISOString()} peakOnline=${peakOnline} hourDeleted=${cleanup.hourDeleted} dayDeleted=${cleanup.dayDeleted}`,
+      );
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`daily rollup failed durationMs=${Date.now() - startedAt}`, stack);
+      throw error;
+    } finally {
+      await this.releaseLock(this.dailyRollupLockKey, lockValue);
+    }
+  }
+
+  private async cleanupHistory(referenceDate = new Date()): Promise<CleanupStats> {
+    const currentHourStart = this.startOfUtcHour(referenceDate);
+    const currentDayStart = this.startOfUtcDay(referenceDate);
+    const hourRetentionBoundary = this.addHours(currentHourStart, -72);
+    const dayRetentionBoundary = this.addYears(currentDayStart, -3);
+
+    const hourDelete = await this.presenceHistoryRepo
+      .createQueryBuilder()
+      .delete()
+      .from(PresenceHistory)
+      .where('bucket_kind = :bucketKind', { bucketKind: 'hour' })
+      .andWhere('bucket_start < :boundary', {
+        boundary: hourRetentionBoundary.toISOString(),
+      })
+      .execute();
+    const dayDelete = await this.presenceHistoryRepo
+      .createQueryBuilder()
+      .delete()
+      .from(PresenceHistory)
+      .where('bucket_kind = :bucketKind', { bucketKind: 'day' })
+      .andWhere('bucket_start < :boundary', {
+        boundary: dayRetentionBoundary.toISOString(),
+      })
+      .execute();
+
+    return {
+      hourDeleted: hourDelete.affected ?? 0,
+      dayDeleted: dayDelete.affected ?? 0,
+    };
+  }
+
+  private async getHourlyPresenceHistory(
+    referenceDate = new Date(),
+  ): Promise<PresenceHistoryPoint[]> {
+    const currentHourStart = this.startOfUtcHour(referenceDate);
+    const firstBucket = this.addHours(currentHourStart, -71);
+    const lastClosedHour = this.addHours(currentHourStart, -1);
+    const rows = await this.readHistoryRows('hour', firstBucket, this.addHours(lastClosedHour, 1));
+    const rowsByBucket = new Map(rows.map((row) => [row.bucketStart, row.peakOnline]));
+    const provisionalPeak = await this.getCurrentHourPeak(referenceDate);
+
+    const points: PresenceHistoryPoint[] = [];
+    for (
+      let cursor = firstBucket;
+      cursor.getTime() <= currentHourStart.getTime();
+      cursor = this.addHours(cursor, 1)
+    ) {
+      const bucketStart = cursor.toISOString();
+      const provisional = cursor.getTime() === currentHourStart.getTime();
+      points.push({
+        bucketStart,
+        peakOnline: provisional ? provisionalPeak : (rowsByBucket.get(bucketStart) ?? 0),
+        provisional,
+      });
+    }
+
+    return points;
+  }
+
+  private async getDailyPresenceHistory(
+    dayCount: number,
+    referenceDate = new Date(),
+  ): Promise<PresenceHistoryPoint[]> {
+    const currentDayStart = this.startOfUtcDay(referenceDate);
+    const firstBucket = this.addDays(currentDayStart, -dayCount);
+    const lastBucket = this.addDays(currentDayStart, -1);
+    const rows = await this.readHistoryRows('day', firstBucket, currentDayStart);
+    const rowsByBucket = new Map(rows.map((row) => [row.bucketStart, row.peakOnline]));
+
+    const points: PresenceHistoryPoint[] = [];
+    for (
+      let cursor = firstBucket;
+      cursor.getTime() <= lastBucket.getTime();
+      cursor = this.addDays(cursor, 1)
+    ) {
+      const bucketStart = cursor.toISOString();
+      points.push({
+        bucketStart,
+        peakOnline: rowsByBucket.get(bucketStart) ?? 0,
+        provisional: false,
+      });
+    }
+
+    return points;
+  }
+
+  private async readHistoryRows(
+    bucketKind: PresenceHistoryBucketKind,
+    fromInclusive: Date,
+    toExclusive: Date,
+  ): Promise<Array<{ bucketStart: string; peakOnline: number }>> {
+    const rows: Array<{ bucket_start: string | Date; peak_online: string | number }> =
+      await this.presenceHistoryRepo.query(
+        `
+          SELECT bucket_start, peak_online
+          FROM presence_history
+          WHERE bucket_kind = $1
+            AND bucket_start >= $2
+            AND bucket_start < $3
+          ORDER BY bucket_start ASC
+        `,
+        [bucketKind, fromInclusive.toISOString(), toExclusive.toISOString()],
+      );
+
+    return rows.map((row) => ({
+      bucketStart: new Date(row.bucket_start).toISOString(),
+      peakOnline: Number(row.peak_online),
+    }));
+  }
+
+  private async findDailyPeak(previousDayStart: Date, currentDayStart: Date): Promise<number> {
+    const rows: Array<{ peak_online: string | number }> = await this.presenceHistoryRepo.query(
+      `
+        SELECT COALESCE(MAX(peak_online), 0) AS peak_online
+        FROM presence_history
+        WHERE bucket_kind = 'hour'
+          AND bucket_start >= $1
+          AND bucket_start < $2
+      `,
+      [previousDayStart.toISOString(), currentDayStart.toISOString()],
+    );
+
+    return Number(rows[0]?.peak_online ?? 0);
+  }
+
+  private async getCurrentHourPeak(referenceDate = new Date()): Promise<number> {
+    const peakKey = this.buildHourPeakKey(this.startOfUtcHour(referenceDate));
+    const peak = await this.redis.get(peakKey);
+    return peak === null ? 0 : this.toInteger(peak, 'current hour peak');
+  }
+
+  private async upsertHistoryBucket(
+    bucketKind: PresenceHistoryBucketKind,
+    bucketStart: Date,
+    peakOnline: number,
+  ): Promise<void> {
+    await this.presenceHistoryRepo.query(
+      `
+        INSERT INTO presence_history (
+          bucket_kind,
+          bucket_start,
+          peak_online
+        )
+        VALUES ($1, $2, $3)
+        ON CONFLICT (bucket_kind, bucket_start) DO UPDATE SET
+          peak_online = GREATEST(
+            presence_history.peak_online,
+            EXCLUDED.peak_online
+          ),
+          updated_at = now()
+      `,
+      [bucketKind, bucketStart.toISOString(), peakOnline],
+    );
+  }
+
+  private async acquireLock(lockKey: string, ttlMs: number): Promise<string | null> {
+    const lockValue = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+    const acquired = await this.redis.set(lockKey, lockValue, 'PX', ttlMs, 'NX');
+    return acquired === 'OK' ? lockValue : null;
+  }
+
+  private async releaseLock(lockKey: string, lockValue: string): Promise<void> {
+    try {
+      await this.redis.eval(this.releaseLockScript, 1, lockKey, lockValue);
+    } catch (error) {
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.warn(`Could not release lock ${lockKey}`, stack);
+    }
+  }
+
   private resolveMember(identity: PresenceIdentity): string {
     const authenticatedUserId = identity.authenticatedUserId?.trim();
     if (authenticatedUserId) {
@@ -105,6 +469,40 @@ export class PresenceService {
     }
 
     return `visitor:${visitorId}`;
+  }
+
+  private buildHourPeakKey(hourStart: Date): string {
+    return `${this.hourPeakKeyPrefix}${hourStart.toISOString()}`;
+  }
+
+  private startOfUtcHour(referenceDate: Date): Date {
+    const date = new Date(referenceDate);
+    date.setUTCMinutes(0, 0, 0);
+    return date;
+  }
+
+  private startOfUtcDay(referenceDate: Date): Date {
+    const date = new Date(referenceDate);
+    date.setUTCHours(0, 0, 0, 0);
+    return date;
+  }
+
+  private addHours(referenceDate: Date, hours: number): Date {
+    const date = new Date(referenceDate);
+    date.setUTCHours(date.getUTCHours() + hours);
+    return date;
+  }
+
+  private addDays(referenceDate: Date, days: number): Date {
+    const date = new Date(referenceDate);
+    date.setUTCDate(date.getUTCDate() + days);
+    return date;
+  }
+
+  private addYears(referenceDate: Date, years: number): Date {
+    const date = new Date(referenceDate);
+    date.setUTCFullYear(date.getUTCFullYear() + years);
+    return date;
   }
 
   private getCutoffMs(referenceMs: number): number {


### PR DESCRIPTION
## Summary

- Persist hourly and daily presence history buckets in Postgres, including Redis-backed peak tracking, scheduled rollups, retention cleanup, and automated coverage.
- Expose active session counts and concurrent-user history through the admin API for dashboard reporting.
- Document the required SQL setup, environment variables, schedules, and admin history endpoint for deployment.

## User-facing changelog

No user-facing changes.

## How to test

```bash
npm run lint
npm test
npm run build
```

- Apply `database/sql/create_presence_history.sql` in the target database.
- Send presence heartbeats and verify `GET /admin/presence/history?range=72h` returns hourly points including a provisional current-hour bucket.
- Verify `GET /admin/overview` includes `activeSessions` and that `GET /admin/presence/history?range=30d` and `range=1y` return zero-filled history in UTC.

## Notes

- Manual SQL setup is required in each TST/PRO database because this repository does not ship TypeORM migrations yet.
