### PR TITLE
Feat/add account username support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,21 @@ npm run sync:items:mapping -- --chunkSize=1000
 ## Supabase Auth test endpoint
 
 - `GET /me` is protected and expects `Authorization: Bearer <access_token>`.
-- Only `/me` is protected; existing endpoints are unchanged.
+- `POST /me/account-username` is protected and sets the authenticated account username once.
+- Both endpoints are also available under `/users/me` for compatibility.
 - Token validation is done with Supabase JWKS: `${SUPABASE_PROJECT_URL}/auth/v1/.well-known/jwks.json`.
 - Issuer is validated as `${SUPABASE_PROJECT_URL}/auth/v1`.
 - `GET /me` auto-upserts the authenticated user in `public.users`:
   - Creates user if missing with `plan='free'` and `role='user'`.
-  - Returns `{ data: { id, email, plan, role } }`.
+  - Leaves `account_username` as `NULL` until onboarding is completed.
+  - Returns `{ data: { id, email, username, plan, role } }`.
   - If user exists and email changed, updates email and `updated_at`.
+- `POST /me/account-username`:
+  - Accepts `{ "username": string }`.
+  - Trims and normalizes to lowercase before validation and storage.
+  - Allows only `a-z`, `0-9`, `_`, must start with a letter or number, and must be 3-20 characters long.
+  - Rejects reserved values such as `admin`, `moderator`, `support`, `root`, `system`, `osrstool`, and `rsmethods`.
+  - Returns `409 Conflict` when the username is already taken or the current user already set one.
 
 ## SQL setup for `public.users`
 
@@ -206,11 +214,16 @@ Admin history endpoint:
 CREATE TABLE IF NOT EXISTS public.users (
   id uuid PRIMARY KEY,
   email text NOT NULL,
+  account_username text NULL,
   plan text NOT NULL DEFAULT 'free',
   role text NOT NULL DEFAULT 'user',
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_account_username_unique_ci
+ON public.users (LOWER(account_username))
+WHERE account_username IS NOT NULL;
 ```
 
 Optional trigger to auto-update `updated_at` on DB-side updates:
@@ -244,6 +257,14 @@ const me = await fetch('http://localhost:3000/me', {
 
 ```bash
 curl -H "Authorization: Bearer <access_token>" http://localhost:3000/me
+```
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"account_user"}' \
+  http://localhost:3000/me/account-username
 ```
   
 ## Production tips

--- a/pr_msg.md
+++ b/pr_msg.md
@@ -1,0 +1,11 @@
+﻿feat: add completed account username onboarding and enforce it across methods/admin routes
+
+This branch introduces support for completing and storing an authenticated user's account username via the Supabase auth flow. It also enforces profile completion for protected methods and admin routes that require a completed account username.
+
+Highlights:
+- Add `POST /me/account-username` endpoint for username completion
+- Persist normalized, lowercase `account_username` on the user record
+- Add database migration and unique case-insensitive username index
+- Add `CompleteProfileGuard` and enforce it for admin and methods endpoints
+- Refine methods service auth handling to return structured account username errors
+- Refactor presence service tests for stable timers and mocks

--- a/sql/2026-08-05-add-users-account-username.sql
+++ b/sql/2026-08-05-add-users-account-username.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.users
+ADD COLUMN IF NOT EXISTS account_username text NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_account_username_unique_ci
+ON public.users (LOWER(account_username))
+WHERE account_username IS NOT NULL;

--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -1,6 +1,7 @@
 import { NotImplementedException } from '@nestjs/common';
 import { GUARDS_METADATA } from '@nestjs/common/constants';
 import type { Request } from 'express';
+import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
 import { PresenceHistoryRange } from '../presence/dto/presence-history-query.dto';
@@ -8,10 +9,10 @@ import { AdminController } from './admin.controller';
 import type { AdminService } from './admin.service';
 
 describe('AdminController guard metadata', () => {
-  it('requires SupabaseAuthGuard and SuperAdminGuard for all admin routes', () => {
+  it('requires SupabaseAuthGuard, CompleteProfileGuard and SuperAdminGuard for all admin routes', () => {
     const guards = Reflect.getMetadata(GUARDS_METADATA, AdminController) as unknown[];
 
-    expect(guards).toEqual([SupabaseAuthGuard, SuperAdminGuard]);
+    expect(guards).toEqual([SupabaseAuthGuard, CompleteProfileGuard, SuperAdminGuard]);
   });
 });
 

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 import type { Request } from 'express';
 import type { AuthenticatedUser } from '../auth/auth.types';
+import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
 import {
@@ -32,7 +33,7 @@ type RequestWithUser = Request & { user: AuthenticatedUser };
 
 @ApiTags('admin')
 @ApiBearerAuth()
-@UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+@UseGuards(SupabaseAuthGuard, CompleteProfileGuard, SuperAdminGuard)
 @Controller('admin')
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}

--- a/src/auth/account-username-required.exception.ts
+++ b/src/auth/account-username-required.exception.ts
@@ -1,0 +1,12 @@
+import { ForbiddenException } from '@nestjs/common';
+
+export const ACCOUNT_USERNAME_REQUIRED_ERROR_CODE = 'ACCOUNT_USERNAME_REQUIRED';
+export const ACCOUNT_USERNAME_REQUIRED_MESSAGE =
+  'You must set an account username before using this service.';
+
+export function createAccountUsernameRequiredException(): ForbiddenException {
+  return new ForbiddenException({
+    code: ACCOUNT_USERNAME_REQUIRED_ERROR_CODE,
+    message: ACCOUNT_USERNAME_REQUIRED_MESSAGE,
+  });
+}

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,69 @@
+import { ForbiddenException } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import type { AuthService } from './auth.service';
+
+describe('AuthController', () => {
+  it('returns the authenticated profile including account username', async () => {
+    const authService = {
+      getOrCreateUser: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'user@example.com',
+        accountUsername: 'account_user',
+        plan: 'free',
+        role: 'user',
+      }),
+      getGivenLikesCount: jest.fn().mockResolvedValue(3),
+    } as unknown as AuthService;
+    const controller = new AuthController(authService);
+
+    await expect(
+      controller.getMe({
+        user: { id: 'user-1', email: 'user@example.com' },
+      } as never),
+    ).resolves.toEqual({
+      data: {
+        id: 'user-1',
+        email: 'user@example.com',
+        username: 'account_user',
+        plan: 'free',
+        role: 'user',
+        likes: 3,
+      },
+    });
+  });
+
+  it('completes account username for the authenticated user', async () => {
+    const authService = {
+      setAccountUsername: jest.fn().mockResolvedValue({
+        accountUsername: 'account_user',
+      }),
+    } as unknown as AuthService;
+    const controller = new AuthController(authService);
+
+    await expect(
+      controller.completeAccountUsername(
+        {
+          user: { id: 'user-1', email: 'user@example.com' },
+        } as never,
+        { username: 'Account_User' },
+      ),
+    ).resolves.toEqual({
+      data: {
+        username: 'account_user',
+      },
+    });
+  });
+
+  it('rejects profile completion when authenticated user id is missing', async () => {
+    const controller = new AuthController({} as AuthService);
+
+    await expect(
+      controller.completeAccountUsername(
+        {
+          user: { id: '', email: 'user@example.com' },
+        } as never,
+        { username: 'account_user' },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, ForbiddenException, Get, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, ForbiddenException, Get, Post, Req, UseGuards } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiConflictResponse,
   ApiForbiddenResponse,
   ApiOkResponse,
   ApiOperation,
@@ -9,6 +11,7 @@ import {
 } from '@nestjs/swagger';
 import type { Request } from 'express';
 import { AuthService } from './auth.service';
+import { CompleteAccountUsernameDto } from './dto/complete-account-username.dto';
 import { SupabaseAuthGuard } from './supabase-auth.guard';
 import type { AuthenticatedUser } from './auth.types';
 
@@ -33,6 +36,7 @@ export class AuthController {
         data: {
           id: 'e3f5b8d0-5f52-46f4-8f8a-87d8ad4bf2f4',
           email: 'user@example.com',
+          username: 'osrs_user_1',
           plan: 'free',
           role: 'user',
           likes: 3,
@@ -57,9 +61,57 @@ export class AuthController {
       data: {
         id: user.id,
         email: user.email,
+        username: user.accountUsername,
         plan: user.plan,
         role: user.role,
         likes,
+      },
+    };
+  }
+
+  @Post(['me/account-username', 'users/me/account-username'])
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Complete authenticated profile with an account username',
+    description:
+      'Sets the authenticated user account username once. The value is trimmed, normalized to lowercase, validated, and stored in public.users.',
+  })
+  @ApiOkResponse({
+    description: 'Account username completed',
+    schema: {
+      example: {
+        data: {
+          username: 'osrs_user_1',
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: 'Invalid or reserved username' })
+  @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired bearer token' })
+  @ApiForbiddenResponse({ description: 'Authenticated token does not include user id' })
+  @ApiConflictResponse({
+    description: 'Username is already taken or the authenticated user has already set one',
+  })
+  async completeAccountUsername(
+    @Req() req: RequestWithUser,
+    @Body() dto: CompleteAccountUsernameDto,
+  ) {
+    if (!req.user?.id) {
+      throw new ForbiddenException('Authenticated user id is required');
+    }
+
+    const user = await this.authService.setAccountUsername(
+      {
+        id: req.user.id,
+        email: req.user.email,
+      },
+      dto.username,
+    );
+
+    return {
+      data: {
+        username: user.accountUsername,
       },
     };
   }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { CompleteProfileGuard } from './complete-profile.guard';
 import { OptionalSupabaseAuthGuard } from './optional-supabase-auth.guard';
 import { SupabaseAuthGuard } from './supabase-auth.guard';
 import { SuperAdminGuard } from './super-admin.guard';
@@ -11,7 +12,19 @@ import { MethodVariant } from '../methods/entities/variant.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([User, MethodVariant])],
   controllers: [AuthController],
-  providers: [SupabaseAuthGuard, OptionalSupabaseAuthGuard, SuperAdminGuard, AuthService],
-  exports: [SupabaseAuthGuard, OptionalSupabaseAuthGuard, SuperAdminGuard, AuthService],
+  providers: [
+    SupabaseAuthGuard,
+    OptionalSupabaseAuthGuard,
+    CompleteProfileGuard,
+    SuperAdminGuard,
+    AuthService,
+  ],
+  exports: [
+    SupabaseAuthGuard,
+    OptionalSupabaseAuthGuard,
+    CompleteProfileGuard,
+    SuperAdminGuard,
+    AuthService,
+  ],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { AuthService } from './auth.service';
 import { User } from './entities/user.entity';
@@ -36,6 +37,7 @@ describe('AuthService', () => {
     repo.create.mockReturnValue({
       id: 'a42cf41b-2e77-4478-aedf-6cb1f8bce205',
       email: 'user@example.com',
+      accountUsername: null,
       plan: 'free',
       role: 'user',
     } as User);
@@ -49,6 +51,7 @@ describe('AuthService', () => {
     expect(repo.create).toHaveBeenCalledWith({
       id: 'a42cf41b-2e77-4478-aedf-6cb1f8bce205',
       email: 'user@example.com',
+      accountUsername: null,
       plan: 'free',
       role: 'user',
     });
@@ -60,6 +63,7 @@ describe('AuthService', () => {
     const existing = {
       id: 'a42cf41b-2e77-4478-aedf-6cb1f8bce205',
       email: 'user@example.com',
+      accountUsername: null,
       plan: 'free',
       role: 'user',
     } as User;
@@ -78,6 +82,7 @@ describe('AuthService', () => {
     const existing = {
       id: 'a42cf41b-2e77-4478-aedf-6cb1f8bce205',
       email: 'old@example.com',
+      accountUsername: null,
       plan: 'free',
       role: 'user',
     } as User;
@@ -104,5 +109,124 @@ describe('AuthService', () => {
       { userId: 'a42cf41b-2e77-4478-aedf-6cb1f8bce205' },
     );
     expect(likes).toBe(7);
+  });
+
+  it('normalizes and saves account username once', async () => {
+    const existing = {
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+      plan: 'free',
+      role: 'user',
+    } as User;
+    repo.findOne.mockResolvedValue(existing);
+    repo.save.mockImplementation((value) => Promise.resolve(value as User));
+
+    const result = await service.setAccountUsername(
+      {
+        id: 'user-1',
+        email: 'user@example.com',
+      },
+      '  Account_User  ',
+    );
+
+    expect(repo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ accountUsername: 'account_user' }),
+    );
+    expect(result.accountUsername).toBe('account_user');
+  });
+
+  it('rejects invalid account username format', async () => {
+    repo.findOne.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+    } as User);
+
+    await expect(
+      service.setAccountUsername(
+        {
+          id: 'user-1',
+          email: 'user@example.com',
+        },
+        '_bad',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects missing account username', async () => {
+    repo.findOne.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+    } as User);
+
+    await expect(
+      service.setAccountUsername(
+        {
+          id: 'user-1',
+          email: 'user@example.com',
+        },
+        undefined as unknown as string,
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects reserved account usernames', async () => {
+    repo.findOne.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+    } as User);
+
+    await expect(
+      service.setAccountUsername(
+        {
+          id: 'user-1',
+          email: 'user@example.com',
+        },
+        'Admin',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects when account username is already set for the current user', async () => {
+    repo.findOne.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: 'existing_user',
+    } as User);
+
+    await expect(
+      service.setAccountUsername(
+        {
+          id: 'user-1',
+          email: 'user@example.com',
+        },
+        'new_user',
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('maps unique violations to conflict for race-safe duplicate handling', async () => {
+    repo.findOne.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+    } as User);
+    repo.save.mockRejectedValue({
+      code: '23505',
+      constraint: 'idx_users_account_username_unique_ci',
+    });
+
+    await expect(
+      service.setAccountUsername(
+        {
+          id: 'user-1',
+          email: 'user@example.com',
+        },
+        'account_user',
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,9 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { AuthenticatedUser } from './auth.types';
 import { User } from './entities/user.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
+
+const ACCOUNT_USERNAME_MIN_LENGTH = 3;
+const ACCOUNT_USERNAME_MAX_LENGTH = 20;
+const ACCOUNT_USERNAME_PATTERN = /^[a-z0-9][a-z0-9_]{2,19}$/;
+const RESERVED_ACCOUNT_USERNAMES = new Set([
+  'admin',
+  'administrator',
+  'moderator',
+  'mod',
+  'support',
+  'staff',
+  'root',
+  'system',
+  'osrstool',
+  'rsmethods',
+]);
 
 @Injectable()
 export class AuthService {
@@ -23,6 +39,7 @@ export class AuthService {
         this.userRepo.create({
           id: authUser.id,
           email: nextEmail,
+          accountUsername: null,
           plan: 'free',
           role: 'user',
         }),
@@ -37,10 +54,82 @@ export class AuthService {
     return existingUser;
   }
 
+  async setAccountUsername(
+    authUser: Pick<AuthenticatedUser, 'id' | 'email'>,
+    username: string,
+  ): Promise<User> {
+    const user = await this.getOrCreateUser(authUser);
+
+    if (user.accountUsername) {
+      throw new ConflictException('Account username is already set and cannot be changed');
+    }
+
+    if (typeof username !== 'string') {
+      throw new BadRequestException('username is required');
+    }
+
+    const normalizedUsername = this.normalizeAccountUsername(username);
+    this.validateAccountUsername(normalizedUsername);
+    user.accountUsername = normalizedUsername;
+
+    try {
+      return await this.userRepo.save(user);
+    } catch (error) {
+      if (this.isAccountUsernameConflictError(error)) {
+        throw new ConflictException('Account username is already taken');
+      }
+
+      throw error;
+    }
+  }
+
   async getGivenLikesCount(userId: string): Promise<number> {
     return this.variantRepo
       .createQueryBuilder('method_variant')
       .where(':userId = ANY(method_variant.liked_user_ids)', { userId })
       .getCount();
+  }
+
+  private normalizeAccountUsername(value: string): string {
+    return value.trim().toLowerCase();
+  }
+
+  private validateAccountUsername(value: string): void {
+    if (!value) {
+      throw new BadRequestException('username is required');
+    }
+
+    if (value.length < ACCOUNT_USERNAME_MIN_LENGTH || value.length > ACCOUNT_USERNAME_MAX_LENGTH) {
+      throw new BadRequestException(
+        `username must be between ${ACCOUNT_USERNAME_MIN_LENGTH} and ${ACCOUNT_USERNAME_MAX_LENGTH} characters`,
+      );
+    }
+
+    if (!ACCOUNT_USERNAME_PATTERN.test(value)) {
+      throw new BadRequestException(
+        'username must start with a letter or number and contain only lowercase letters, numbers, and underscores',
+      );
+    }
+
+    if (RESERVED_ACCOUNT_USERNAMES.has(value)) {
+      throw new BadRequestException('username is reserved');
+    }
+  }
+
+  private isAccountUsernameConflictError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const candidate = error as { code?: unknown; constraint?: unknown; detail?: unknown };
+    if (candidate.code !== '23505') {
+      return false;
+    }
+
+    return (
+      candidate.constraint === 'users_account_username_unique_ci' ||
+      candidate.constraint === 'idx_users_account_username_unique_ci' ||
+      (typeof candidate.detail === 'string' && candidate.detail.includes('account_username'))
+    );
   }
 }

--- a/src/auth/complete-profile.guard.spec.ts
+++ b/src/auth/complete-profile.guard.spec.ts
@@ -1,0 +1,65 @@
+import { UnauthorizedException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { ACCOUNT_USERNAME_REQUIRED_ERROR_CODE } from './account-username-required.exception';
+import { CompleteProfileGuard } from './complete-profile.guard';
+import type { AuthService } from './auth.service';
+
+function createHttpExecutionContext(request: Record<string, unknown>): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as ExecutionContext;
+}
+
+describe('CompleteProfileGuard', () => {
+  it('rejects when authenticated user context is missing', async () => {
+    const guard = new CompleteProfileGuard({} as AuthService);
+
+    await expect(guard.canActivate(createHttpExecutionContext({}))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects when account username is missing', async () => {
+    const authService = {
+      getOrCreateUser: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'user@example.com',
+        accountUsername: null,
+      }),
+    } as unknown as AuthService;
+    const guard = new CompleteProfileGuard(authService);
+
+    await expect(
+      guard.canActivate(
+        createHttpExecutionContext({
+          user: { id: 'user-1', email: 'user@example.com' },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      response: {
+        code: ACCOUNT_USERNAME_REQUIRED_ERROR_CODE,
+      },
+    });
+  });
+
+  it('allows access when account username is present', async () => {
+    const authService = {
+      getOrCreateUser: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'user@example.com',
+        accountUsername: 'account_user',
+      }),
+    } as unknown as AuthService;
+    const guard = new CompleteProfileGuard(authService);
+
+    await expect(
+      guard.canActivate(
+        createHttpExecutionContext({
+          user: { id: 'user-1', email: 'user@example.com' },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/src/auth/complete-profile.guard.ts
+++ b/src/auth/complete-profile.guard.ts
@@ -1,0 +1,32 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import type { Request } from 'express';
+import { AuthService } from './auth.service';
+import type { AuthenticatedUser } from './auth.types';
+import { createAccountUsernameRequiredException } from './account-username-required.exception';
+
+type RequestWithUser = Request & { user?: AuthenticatedUser };
+
+@Injectable()
+export class CompleteProfileGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<RequestWithUser>();
+    const authUser = req.user;
+
+    if (!authUser?.id) {
+      throw new UnauthorizedException('Missing authenticated user context');
+    }
+
+    const user = await this.authService.getOrCreateUser({
+      id: authUser.id,
+      email: authUser.email,
+    });
+
+    if (!user.accountUsername) {
+      throw createAccountUsernameRequiredException();
+    }
+
+    return true;
+  }
+}

--- a/src/auth/dto/complete-account-username.dto.ts
+++ b/src/auth/dto/complete-account-username.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Length, Matches } from 'class-validator';
+
+export class CompleteAccountUsernameDto {
+  @ApiProperty({
+    example: 'osrs_user_1',
+    description:
+      'Account username to set once for the authenticated profile. It is trimmed and normalized to lowercase before validation and storage.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(3, 20)
+  @Matches(/^[a-zA-Z0-9][a-zA-Z0-9_]{2,19}$/, {
+    message:
+      'username must start with a letter or number and contain only letters, numbers, and underscores',
+  })
+  username: string;
+}

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -8,6 +8,9 @@ export class User {
   @Column({ type: 'text' })
   email: string;
 
+  @Column({ name: 'account_username', type: 'text', nullable: true })
+  accountUsername: string | null;
+
   @Column({ type: 'text', default: 'free' })
   plan: string;
 

--- a/src/methods/methods.controller.spec.ts
+++ b/src/methods/methods.controller.spec.ts
@@ -6,6 +6,7 @@ jest.mock('jose', () => ({
 import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { BadRequestException } from '@nestjs/common';
 import type { Request } from 'express';
+import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
 import { MethodsController } from './methods.controller';
@@ -69,7 +70,7 @@ describe('MethodsController skills summary endpoint', () => {
 });
 
 describe('MethodsController skill roadmap endpoint', () => {
-  it('requires SupabaseAuthGuard for the roadmap endpoint', () => {
+  it('requires SupabaseAuthGuard and CompleteProfileGuard for the roadmap endpoint', () => {
     const descriptor = Object.getOwnPropertyDescriptor(
       MethodsController.prototype,
       'findSkillRoadmap',
@@ -80,7 +81,7 @@ describe('MethodsController skill roadmap endpoint', () => {
     const handler = descriptor?.value as object;
     const guards = Reflect.getMetadata(GUARDS_METADATA, handler) as unknown[];
 
-    expect(guards).toEqual([SupabaseAuthGuard]);
+    expect(guards).toEqual([SupabaseAuthGuard, CompleteProfileGuard]);
   });
 
   it('rejects query params outside the roadmap contract', async () => {

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -24,6 +24,7 @@ import {
 import type { Request } from 'express';
 import { MethodsService } from './methods.service';
 import { CreateMethodDto, UpdateMethodDto, UpdateMethodBasicDto, UpdateVariantDto } from './dto';
+import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
 import type { AuthenticatedUser } from '../auth/auth.types';
@@ -366,12 +367,12 @@ export class MethodsController {
   }
 
   @Get('skills/roadmap')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, CompleteProfileGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get a skill roadmap',
     description:
-      'Returns a level-range roadmap to reach a target level in one skill using the current enabled method variants. Requires authentication, a registered user, and a RuneScape username.',
+      'Returns a level-range roadmap to reach a target level in one skill using the current enabled method variants. Requires authentication, a completed account username, and a RuneScape username.',
   })
   @ApiQuery({
     name: 'username',
@@ -416,7 +417,7 @@ export class MethodsController {
     },
   })
   @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired bearer token' })
-  @ApiForbiddenResponse({ description: 'Only registered users can use this endpoint' })
+  @ApiForbiddenResponse({ description: 'Complete your account username to use this endpoint' })
   async findSkillRoadmap(
     @Query('username') username?: string,
     @Query('skill') skill?: string,
@@ -584,7 +585,7 @@ export class MethodsController {
   }
 
   @Post('variant/:variantId/like')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, CompleteProfileGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Like method variant',
@@ -603,7 +604,7 @@ export class MethodsController {
   }
 
   @Delete('variant/:variantId/like')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, CompleteProfileGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Unlike method variant',

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -13,6 +13,7 @@ import { BadRequestException, ForbiddenException, UnauthorizedException } from '
 import { Item } from '../items/entities/item.entity';
 import { VARIANT_TAG_DEFINITIONS } from './variant-tags';
 import { ActionType } from './action-type.enum';
+import { ACCOUNT_USERNAME_REQUIRED_ERROR_CODE } from '../auth/account-username-required.exception';
 
 type MethodDetailsWithProfitResult = Awaited<
   ReturnType<MethodsService['findMethodDetailsWithProfit']>
@@ -736,13 +737,13 @@ describe('MethodsService variantCount', () => {
     expect(Number.isInteger(result.meta.computedAt)).toBe(true);
   });
 
-  it('throws when username is sent by a non-registered user', async () => {
+  it('throws when username is sent by a user without a completed account username', async () => {
     const methodRepo = {
       find: jest.fn().mockResolvedValue([]),
     } as unknown as Repository<Method>;
 
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue(null),
+      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: null }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -766,7 +767,11 @@ describe('MethodsService variantCount', () => {
         username: 'zezima',
         authorization: 'Bearer token',
       }),
-    ).rejects.toBeInstanceOf(ForbiddenException);
+    ).rejects.toMatchObject({
+      response: {
+        code: ACCOUNT_USERNAME_REQUIRED_ERROR_CODE,
+      },
+    });
   });
 
   it('does not require auth when username is not sent', async () => {
@@ -804,13 +809,13 @@ describe('MethodsService variantCount', () => {
     expect(result.status).toBe('ok');
   });
 
-  it('throws on skill summaries when username is sent by a non-registered user', async () => {
+  it('throws on skill summaries when username is sent by a user without a completed account username', async () => {
     const methodRepo = {
       find: jest.fn().mockResolvedValue([]),
     } as unknown as Repository<Method>;
 
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue(null),
+      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: null }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -829,7 +834,11 @@ describe('MethodsService variantCount', () => {
 
     await expect(
       service.skillsSummaryWithProfitResponse('zezima', 'Bearer token'),
-    ).rejects.toBeInstanceOf(ForbiddenException);
+    ).rejects.toMatchObject({
+      response: {
+        code: ACCOUNT_USERNAME_REQUIRED_ERROR_CODE,
+      },
+    });
   });
 
   it('supports enabled=false on skill summaries for super admins', async () => {
@@ -839,7 +848,9 @@ describe('MethodsService variantCount', () => {
     } as unknown as Repository<Method>;
 
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'super_admin' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'super_admin', accountUsername: 'admin_user' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -871,7 +882,9 @@ describe('MethodsService variantCount', () => {
     } as unknown as Repository<Method>;
 
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -918,7 +931,9 @@ describe('MethodsService variantCount', () => {
 
   it('throws when enabled query param is sent by a non-super admin on skill roadmap', async () => {
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -946,7 +961,9 @@ describe('MethodsService variantCount', () => {
 
   it('throws when target_level is lower than the player current skill level', async () => {
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -987,7 +1004,9 @@ describe('MethodsService variantCount', () => {
 
   it('builds a fastest roadmap with dynamic skill unlocks and forwards only the requested ignored tags', async () => {
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -1174,7 +1193,9 @@ describe('MethodsService variantCount', () => {
 
   it('uses the provided target_level instead of defaulting to 99', async () => {
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -1263,7 +1284,9 @@ describe('MethodsService variantCount', () => {
 
   it('returns a strict materials warning and null totals when one roadmap range lacks actionsPerHour', async () => {
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -1348,7 +1371,9 @@ describe('MethodsService variantCount', () => {
 
   it('treats null afkiness as 100 for most_afk roadmaps', async () => {
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -1472,6 +1497,43 @@ describe('MethodsService variantCount', () => {
         likedByMe: 'true',
       }),
     ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws when likedByMe=true is sent by a user without a completed account username', async () => {
+    const methodRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    } as unknown as Repository<Method>;
+
+    const userRepo = {
+      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: null }),
+    } as unknown as Repository<User>;
+
+    const service = new MethodsService(
+      methodRepo,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      createMethodLikeRepo(),
+      userRepo,
+      {} as VariantSnapshotService,
+      {} as RuneScapeApiService,
+      { get: jest.fn().mockReturnValue('redis://localhost:6379') } as unknown as ConfigService,
+    );
+
+    jest.spyOn(service as any, 'verifySupabaseToken').mockResolvedValue('user-1');
+
+    await expect(
+      service.listWithProfitResponse({
+        page: '1',
+        perPage: '10',
+        likedByMe: 'true',
+        authorization: 'Bearer token',
+      }),
+    ).rejects.toMatchObject({
+      response: {
+        code: ACCOUNT_USERNAME_REQUIRED_ERROR_CODE,
+      },
+    });
   });
 
   it('returns the official variant tag catalog with severity', () => {
@@ -2152,7 +2214,9 @@ describe('MethodsService variantCount', () => {
     } as unknown as Repository<Method>;
 
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'user' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'user', accountUsername: 'user_1' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(
@@ -2191,7 +2255,9 @@ describe('MethodsService variantCount', () => {
     } as unknown as Repository<Method>;
 
     const userRepo = {
-      findOne: jest.fn().mockResolvedValue({ id: 'user-1', role: 'super_admin' }),
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', role: 'super_admin', accountUsername: 'admin_user' }),
     } as unknown as Repository<User>;
 
     const service = new MethodsService(

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -27,6 +27,7 @@ import { VariantRequirements, XpHour, UserInfo } from './types';
 import { RuneScapeApiService } from './RuneScapeApiService';
 import { computeMissingRequirements, filterMethodsByUserStats } from './helpers/requirements';
 import { ConfigService } from '@nestjs/config';
+import { createAccountUsernameRequiredException } from '../auth/account-username-required.exception';
 import { User } from '../auth/entities/user.entity';
 import { calculateMarketImpact, type MarketImpactResult } from './market-impact-calculator';
 import { Item } from '../items/entities/item.entity';
@@ -878,6 +879,20 @@ export class MethodsService implements OnModuleDestroy {
     }
   }
 
+  private async assertCompletedAccountProfile(
+    userId: string,
+    email?: string | null,
+  ): Promise<User> {
+    await this.ensureUserExists(userId, email);
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+
+    if (!user?.accountUsername) {
+      throw createAccountUsernameRequiredException();
+    }
+
+    return user;
+  }
+
   private getVariantLikesCount(variant: { likesCount?: number | null }): number {
     return variant.likesCount ?? 0;
   }
@@ -892,7 +907,7 @@ export class MethodsService implements OnModuleDestroy {
 
   async likeVariant(variantId: string, userId: string, email?: string | null): Promise<void> {
     const variant = await this.ensureVariantExists(variantId);
-    await this.ensureUserExists(userId, email);
+    await this.assertCompletedAccountProfile(userId, email);
 
     const likedUserIds = variant.likedUserIds ?? [];
     if (likedUserIds.includes(userId)) {
@@ -906,6 +921,7 @@ export class MethodsService implements OnModuleDestroy {
 
   async unlikeVariant(variantId: string, userId: string): Promise<void> {
     const variant = await this.ensureVariantExists(variantId);
+    await this.assertCompletedAccountProfile(userId);
     const likedUserIds = variant.likedUserIds ?? [];
 
     if (!likedUserIds.includes(userId)) {
@@ -923,9 +939,9 @@ export class MethodsService implements OnModuleDestroy {
     authenticatedUserId?: string | null,
   ): Promise<void> {
     const userId = authenticatedUserId ?? (await this.verifySupabaseToken(authorization));
-    const user = await this.userRepo.findOne({ where: { id: userId } });
+    const user = await this.assertCompletedAccountProfile(userId);
 
-    if (!user || user.role !== 'super_admin') {
+    if (user.role !== 'super_admin') {
       throw new ForbiddenException(errorMessage);
     }
   }
@@ -972,13 +988,13 @@ export class MethodsService implements OnModuleDestroy {
     }
 
     const userId = authenticatedUserId ?? (await this.verifySupabaseToken(authorization));
-    const user = await this.userRepo.findOne({ where: { id: userId } });
-    if (!user || user.role !== 'super_admin') {
+    const user = await this.assertCompletedAccountProfile(userId);
+    if (user.role !== 'super_admin') {
       throw new ForbiddenException('Only super_admin can access disabled methods');
     }
   }
 
-  private async assertRegisteredUserForUsername(
+  private async assertCompletedProfileForUsernameQuery(
     username?: string,
     authorization?: string,
     authenticatedUserId?: string | null,
@@ -991,11 +1007,25 @@ export class MethodsService implements OnModuleDestroy {
     if (!normalizedUsername) return;
 
     const userId = authenticatedUserId ?? (await this.verifySupabaseToken(authorization));
-    const user = await this.userRepo.findOne({ where: { id: userId } });
+    await this.assertCompletedAccountProfile(userId);
+  }
 
-    if (!user) {
-      throw new ForbiddenException('Only registered users can use username query parameter');
+  private async assertCompletedProfileForLikedByMeFilter(
+    likedByMeFilter: boolean | undefined,
+    authenticatedUserId?: string | null,
+    authorization?: string,
+  ): Promise<void> {
+    if (likedByMeFilter !== true) {
+      return;
     }
+
+    if (!authenticatedUserId) {
+      throw new UnauthorizedException('likedByMe filter requires authentication');
+    }
+
+    await this.assertCompletedAccountProfile(
+      authenticatedUserId ?? (await this.verifySupabaseToken(authorization)),
+    );
   }
 
   private normalizeOptionalQueryString(
@@ -1175,11 +1205,16 @@ export class MethodsService implements OnModuleDestroy {
     const likedByMeFilter = this.parseBooleanQueryParam(query.likedByMe, 'likedByMe');
     const authenticatedUserId = await this.resolveAuthenticatedUserId(query.authorization);
 
-    if (likedByMeFilter && !authenticatedUserId) {
-      throw new UnauthorizedException('likedByMe filter requires authentication');
-    }
-
-    await this.assertRegisteredUserForUsername(username, query.authorization, authenticatedUserId);
+    await this.assertCompletedProfileForLikedByMeFilter(
+      likedByMeFilter,
+      authenticatedUserId,
+      query.authorization,
+    );
+    await this.assertCompletedProfileForUsernameQuery(
+      username,
+      query.authorization,
+      authenticatedUserId,
+    );
     const { userInfo, warnings } = await this.fetchUserInfo(username);
     const filters = this.buildListFilters(query);
     if (filters.enabled === false) {
@@ -1239,11 +1274,16 @@ export class MethodsService implements OnModuleDestroy {
     const likedByMeFilter = this.parseBooleanQueryParam(query.likedByMe, 'likedByMe');
     const authenticatedUserId = await this.resolveAuthenticatedUserId(query.authorization);
 
-    if (likedByMeFilter && !authenticatedUserId) {
-      throw new UnauthorizedException('likedByMe filter requires authentication');
-    }
-
-    await this.assertRegisteredUserForUsername(username, query.authorization, authenticatedUserId);
+    await this.assertCompletedProfileForLikedByMeFilter(
+      likedByMeFilter,
+      authenticatedUserId,
+      query.authorization,
+    );
+    await this.assertCompletedProfileForUsernameQuery(
+      username,
+      query.authorization,
+      authenticatedUserId,
+    );
     const { userInfo, warnings } = await this.fetchUserInfo(username);
     const filters = this.buildListFilters(query);
     if (filters.enabled === false) {
@@ -1295,7 +1335,7 @@ export class MethodsService implements OnModuleDestroy {
       USERNAME_MAX_LENGTH,
     );
     const authenticatedUserId = await this.resolveAuthenticatedUserId(authorization);
-    await this.assertRegisteredUserForUsername(
+    await this.assertCompletedProfileForUsernameQuery(
       normalizedUsername,
       authorization,
       authenticatedUserId,
@@ -1391,7 +1431,11 @@ export class MethodsService implements OnModuleDestroy {
     const authenticatedUserId =
       query.authenticatedUserId ?? (await this.resolveAuthenticatedUserId(query.authorization));
 
-    await this.assertRegisteredUserForUsername(username, query.authorization, authenticatedUserId);
+    await this.assertCompletedProfileForUsernameQuery(
+      username,
+      query.authorization,
+      authenticatedUserId,
+    );
     if (query.enabled != null) {
       await this.assertSuperAdminForEnabledQueryParam(query.authorization, authenticatedUserId);
     }
@@ -1955,9 +1999,9 @@ export class MethodsService implements OnModuleDestroy {
     await this.timeMethodDetailsStep(
       perfLogsEnabled,
       scope,
-      'assertRegisteredUserForUsername',
+      'assertCompletedProfileForUsernameQuery',
       () =>
-        this.assertRegisteredUserForUsername(
+        this.assertCompletedProfileForUsernameQuery(
           normalizedUsername,
           authorization,
           authenticatedUserId,
@@ -3335,7 +3379,7 @@ export class MethodsService implements OnModuleDestroy {
     likeOptions: ListLikeOptions = {},
     variantsMode: VariantsMode = 'best',
   ): Promise<{ data: any[]; total: number }> {
-    // Obtenemos todos los mÃƒÂ©todos para poder ordenarlos por profit posteriormente
+    // Load every method first so sorting can happen after profit enrichment.
     const allEntities = await this.methodRepo.find({
       where: { enabled: filters.enabled },
       relations: ['variants', 'variants.ioItems'],
@@ -3346,12 +3390,12 @@ export class MethodsService implements OnModuleDestroy {
     }, {});
     let methodsToProcess = allEntities.map((m) => this.toDto(m));
 
-    // Si se pasÃƒÂ³ el objeto userLevels, filtramos los mÃƒÂ©todos antes de enriquecerlos
+    // Apply user-based filtering before enriching variants when user data is available.
     if (userInfo) {
       methodsToProcess = filterMethodsByUserStats(methodsToProcess, userInfo);
     }
 
-    // Enriquecemos la lista (filtrada o no) con la informaciÃƒÂ³n de profit proveniente de Redis
+    // Enrich the current method list with profit data from Redis.
     const itemIds = this.collectItemIdsFromMethods(methodsToProcess);
     const variantIds = methodsToProcess.flatMap((method) =>
       method.variants.map((variant) => variant.id),
@@ -3515,7 +3559,7 @@ export class MethodsService implements OnModuleDestroy {
       });
     }
 
-    // Ordenamiento segÃƒÂºn los parÃƒÂ¡metros recibidos
+    // Sort using the requested client options.
     const comparator = (a: number, b: number) => (sort.order === 'asc' ? a - b : b - a);
 
     const getXpSum = (v: { xpHour?: XpHour | null }): number =>
@@ -3676,7 +3720,7 @@ export class MethodsService implements OnModuleDestroy {
       () =>
         Promise.all(
           methodDto.variants.map(async (variant) => {
-            // Si solo hay una variante se utiliza el id del mÃƒÂ©todo; de lo contrario se usa una clave compuesta
+            // Single-variant methods reuse the variant id as the profit lookup key.
             const profitKey = variant.id;
             const profit = allProfits[profitKey] ?? { low: 0, high: 0 };
             const marketImpact = this.calculateVariantMarketImpact(

--- a/src/presence/presence.service.spec.ts
+++ b/src/presence/presence.service.spec.ts
@@ -87,9 +87,7 @@ describe('PresenceService', () => {
     const { redis } = createRedisMock();
     redis.eval.mockResolvedValue(127);
     const { service } = createService({}, redis);
-    const nowSpy = jest
-      .spyOn(Date, 'now')
-      .mockReturnValue(new Date('2026-08-05T14:33:10.000Z').getTime());
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-05T14:33:10.000Z'));
 
     const online = await service.recordHeartbeat({ visitorId: 'visitor-123' });
 
@@ -105,7 +103,7 @@ describe('PresenceService', () => {
       String(96 * 60 * 60 * 1000),
     );
     expect(online).toBe(127);
-    nowSpy.mockRestore();
+    jest.useRealTimers();
   });
 
   it('counts online users while excluding expired entries', async () => {


### PR DESCRIPTION
feat: add completed account username onboarding and enforce it across methods/admin routes

This branch introduces support for completing and storing an authenticated user's account username via the Supabase auth flow. It also enforces profile completion for protected methods and admin routes that require a completed account username.

Highlights:
- Add `POST /me/account-username` endpoint for username completion
- Persist normalized, lowercase `account_username` on the user record
- Add database migration and unique case-insensitive username index
- Add `CompleteProfileGuard` and enforce it for admin and methods endpoints
- Refine methods service auth handling to return structured account username errors
- Refactor presence service tests for stable timers and mocks
