### PR TITLE
feat: add terms acceptance flow and enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ npm run sync:items:mapping -- --chunkSize=1000
 ## Supabase Auth test endpoint
 
 - `GET /me` is protected and expects `Authorization: Bearer <access_token>`.
+- `POST /me/terms/acceptance` is protected and registers acceptance of the current Terms of Service version for the authenticated user.
 - `POST /me/account-username` is protected and sets the authenticated account username once.
 - Both endpoints are also available under `/users/me` for compatibility.
 - Token validation is done with Supabase JWKS: `${SUPABASE_PROJECT_URL}/auth/v1/.well-known/jwks.json`.
@@ -177,8 +178,12 @@ npm run sync:items:mapping -- --chunkSize=1000
 - `GET /me` auto-upserts the authenticated user in `public.users`:
   - Creates user if missing with `plan='free'` and `role='user'`.
   - Leaves `account_username` as `NULL` until onboarding is completed.
-  - Returns `{ data: { id, email, username, plan, role } }`.
+  - Returns `{ data: { id, email, username, plan, role, terms } }`.
   - If user exists and email changed, updates email and `updated_at`.
+- `POST /me/terms/acceptance`:
+  - Accepts no user id or version input from the client.
+  - Registers acceptance for the authenticated user and the backend-configured current version only.
+  - Is idempotent for repeated attempts on the same version.
 - `POST /me/account-username`:
   - Accepts `{ "username": string }`.
   - Trims and normalizes to lowercase before validation and storage.
@@ -189,6 +194,12 @@ npm run sync:items:mapping -- --chunkSize=1000
 ## SQL setup for `public.users`
 
 This repository does not include TypeORM migrations yet, so create the table manually in Railway/Postgres:
+
+For versioned Terms of Service acceptances, execute this SQL file once per environment:
+
+```txt
+sql/2026-08-17-add-user-terms-acceptances.sql
+```
 
 ## Manual SQL setup for `presence_history`
 
@@ -243,6 +254,7 @@ BEFORE UPDATE ON public.users
 FOR EACH ROW
 EXECUTE FUNCTION public.set_updated_at();
 ```
+
 - In frontend, get the token with Supabase Auth:
 
 ```ts
@@ -266,7 +278,7 @@ curl -X POST \
   -d '{"username":"account_user"}' \
   http://localhost:3000/me/account-username
 ```
-  
+
 ## Production tips
 
 - Set `NODE_ENV=production` to disable Swagger by default.

--- a/pr_msg.md
+++ b/pr_msg.md
@@ -1,11 +1,24 @@
-﻿feat: add completed account username onboarding and enforce it across methods/admin routes
+## Summary
 
-This branch introduces support for completing and storing an authenticated user's account username via the Supabase auth flow. It also enforces profile completion for protected methods and admin routes that require a completed account username.
+- Add versioned Terms of Service acceptance storage, the authenticated acceptance endpoint, and current terms status in the profile response.
+- Enforce current Terms of Service acceptance on protected authenticated, admin, and write endpoints that should require it.
+- Document the new terms acceptance endpoint and manual SQL setup in the backend README.
 
-Highlights:
-- Add `POST /me/account-username` endpoint for username completion
-- Persist normalized, lowercase `account_username` on the user record
-- Add database migration and unique case-insensitive username index
-- Add `CompleteProfileGuard` and enforce it for admin and methods endpoints
-- Refine methods service auth handling to return structured account username errors
-- Refactor presence service tests for stable timers and mocks
+## User-facing changelog
+
+- Signed-in users can now register acceptance of the current Terms of Service through the account API.
+- Protected account and admin actions now require the current Terms of Service to be accepted before they can be used.
+
+## How to test
+
+- `npm run lint`
+- `$env:CI='true'; npm test`
+- `npm run build`
+- Call `GET /me` with a valid bearer token and confirm the response includes `terms.currentVersion` and `terms.accepted`.
+- Call `POST /me/terms/acceptance` with the same token and confirm it returns `accepted: true` and remains idempotent on repeat requests.
+- Call a terms-protected endpoint without a current acceptance record and confirm it returns a `403` response with code `TERMS_ACCEPTANCE_REQUIRED`.
+
+## Notes
+
+- Run `sql/2026-08-17-add-user-terms-acceptances.sql` once in each environment before using the new flow.
+- The backend currently enforces `CURRENT_TERMS_VERSION = v1`.

--- a/sql/2026-08-17-add-user-terms-acceptances.sql
+++ b/sql/2026-08-17-add-user-terms-acceptances.sql
@@ -1,0 +1,22 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.user_terms_acceptances (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  terms_version text NOT NULL,
+  accepted_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT fk_user_terms_acceptances_user
+    FOREIGN KEY (user_id)
+    REFERENCES public.users (id)
+    ON DELETE CASCADE,
+  CONSTRAINT uq_user_terms_acceptances_user_version
+    UNIQUE (user_id, terms_version),
+  CONSTRAINT chk_user_terms_acceptances_terms_version_nonempty
+    CHECK (length(btrim(terms_version)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_terms_acceptances_user_id
+  ON public.user_terms_acceptances (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_terms_acceptances_terms_version
+  ON public.user_terms_acceptances (terms_version);

--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -4,15 +4,21 @@ import type { Request } from 'express';
 import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { TermsAcceptanceGuard } from '../auth/terms-acceptance.guard';
 import { PresenceHistoryRange } from '../presence/dto/presence-history-query.dto';
 import { AdminController } from './admin.controller';
 import type { AdminService } from './admin.service';
 
 describe('AdminController guard metadata', () => {
-  it('requires SupabaseAuthGuard, CompleteProfileGuard and SuperAdminGuard for all admin routes', () => {
+  it('requires SupabaseAuthGuard, TermsAcceptanceGuard, CompleteProfileGuard and SuperAdminGuard for all admin routes', () => {
     const guards = Reflect.getMetadata(GUARDS_METADATA, AdminController) as unknown[];
 
-    expect(guards).toEqual([SupabaseAuthGuard, CompleteProfileGuard, SuperAdminGuard]);
+    expect(guards).toEqual([
+      SupabaseAuthGuard,
+      TermsAcceptanceGuard,
+      CompleteProfileGuard,
+      SuperAdminGuard,
+    ]);
   });
 });
 

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -22,6 +22,7 @@ import type { AuthenticatedUser } from '../auth/auth.types';
 import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { TermsAcceptanceGuard } from '../auth/terms-acceptance.guard';
 import {
   PresenceHistoryQueryDto,
   PresenceHistoryRange,
@@ -33,7 +34,7 @@ type RequestWithUser = Request & { user: AuthenticatedUser };
 
 @ApiTags('admin')
 @ApiBearerAuth()
-@UseGuards(SupabaseAuthGuard, CompleteProfileGuard, SuperAdminGuard)
+@UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, CompleteProfileGuard, SuperAdminGuard)
 @Controller('admin')
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -3,7 +3,7 @@ import { AuthController } from './auth.controller';
 import type { AuthService } from './auth.service';
 
 describe('AuthController', () => {
-  it('returns the authenticated profile including account username', async () => {
+  it('returns the authenticated profile including account username and terms status', async () => {
     const authService = {
       getOrCreateUser: jest.fn().mockResolvedValue({
         id: 'user-1',
@@ -13,6 +13,10 @@ describe('AuthController', () => {
         role: 'user',
       }),
       getGivenLikesCount: jest.fn().mockResolvedValue(3),
+      getCurrentTermsStatusForUser: jest.fn().mockResolvedValue({
+        currentVersion: 'v1',
+        accepted: false,
+      }),
     } as unknown as AuthService;
     const controller = new AuthController(authService);
 
@@ -28,6 +32,10 @@ describe('AuthController', () => {
         plan: 'free',
         role: 'user',
         likes: 3,
+        terms: {
+          currentVersion: 'v1',
+          accepted: false,
+        },
       },
     });
   });
@@ -64,6 +72,39 @@ describe('AuthController', () => {
         } as never,
         { username: 'account_user' },
       ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('accepts the current terms for the authenticated user', async () => {
+    const authService = {
+      acceptCurrentTerms: jest.fn().mockResolvedValue({
+        currentVersion: 'v1',
+        accepted: true,
+      }),
+    } as unknown as AuthService;
+    const controller = new AuthController(authService);
+
+    await expect(
+      controller.acceptTerms({
+        user: { id: 'user-1', email: 'user@example.com' },
+      } as never),
+    ).resolves.toEqual({
+      data: {
+        terms: {
+          currentVersion: 'v1',
+          accepted: true,
+        },
+      },
+    });
+  });
+
+  it('rejects terms acceptance when authenticated user id is missing', async () => {
+    const controller = new AuthController({} as AuthService);
+
+    await expect(
+      controller.acceptTerms({
+        user: { id: '', email: 'user@example.com' },
+      } as never),
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -14,6 +14,7 @@ import { AuthService } from './auth.service';
 import { CompleteAccountUsernameDto } from './dto/complete-account-username.dto';
 import { SupabaseAuthGuard } from './supabase-auth.guard';
 import type { AuthenticatedUser } from './auth.types';
+import { TermsAcceptanceGuard } from './terms-acceptance.guard';
 
 type RequestWithUser = Request & { user: AuthenticatedUser };
 
@@ -51,11 +52,11 @@ export class AuthController {
       throw new ForbiddenException('Authenticated user id is required');
     }
 
-    const user = await this.authService.getOrCreateUser({
-      id: req.user.id,
-      email: req.user.email,
-    });
-    const likes = await this.authService.getGivenLikesCount(user.id);
+    const user = await this.authService.getOrCreateUser(req.user);
+    const [likes, terms] = await Promise.all([
+      this.authService.getGivenLikesCount(user.id),
+      this.authService.getCurrentTermsStatusForUser(user.id),
+    ]);
 
     return {
       data: {
@@ -65,12 +66,13 @@ export class AuthController {
         plan: user.plan,
         role: user.role,
         likes,
+        terms,
       },
     };
   }
 
   @Post(['me/account-username', 'users/me/account-username'])
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Complete authenticated profile with an account username',
@@ -89,7 +91,10 @@ export class AuthController {
   })
   @ApiBadRequestResponse({ description: 'Invalid or reserved username' })
   @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired bearer token' })
-  @ApiForbiddenResponse({ description: 'Authenticated token does not include user id' })
+  @ApiForbiddenResponse({
+    description:
+      'Authenticated token does not include user id or the current Terms of Service have not been accepted',
+  })
   @ApiConflictResponse({
     description: 'Username is already taken or the authenticated user has already set one',
   })
@@ -101,17 +106,48 @@ export class AuthController {
       throw new ForbiddenException('Authenticated user id is required');
     }
 
-    const user = await this.authService.setAccountUsername(
-      {
-        id: req.user.id,
-        email: req.user.email,
-      },
-      dto.username,
-    );
+    const user = await this.authService.setAccountUsername(req.user, dto.username);
 
     return {
       data: {
         username: user.accountUsername,
+      },
+    };
+  }
+
+  @Post(['me/terms/acceptance', 'users/me/terms/acceptance'])
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Accept the current Terms of Service',
+    description:
+      'Registers acceptance of the current backend-configured Terms of Service version for the authenticated user. Idempotent when already accepted.',
+  })
+  @ApiOkResponse({
+    description: 'Terms accepted',
+    schema: {
+      example: {
+        data: {
+          terms: {
+            currentVersion: 'v1',
+            accepted: true,
+          },
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired bearer token' })
+  @ApiForbiddenResponse({ description: 'Authenticated token does not include user id' })
+  async acceptTerms(@Req() req: RequestWithUser) {
+    if (!req.user?.id) {
+      throw new ForbiddenException('Authenticated user id is required');
+    }
+
+    const terms = await this.authService.acceptCurrentTerms(req.user);
+
+    return {
+      data: {
+        terms,
       },
     };
   }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,15 +6,18 @@ import { CompleteProfileGuard } from './complete-profile.guard';
 import { OptionalSupabaseAuthGuard } from './optional-supabase-auth.guard';
 import { SupabaseAuthGuard } from './supabase-auth.guard';
 import { SuperAdminGuard } from './super-admin.guard';
+import { TermsAcceptanceGuard } from './terms-acceptance.guard';
 import { User } from './entities/user.entity';
+import { UserTermsAcceptance } from './entities/user-terms-acceptance.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, MethodVariant])],
+  imports: [TypeOrmModule.forFeature([User, MethodVariant, UserTermsAcceptance])],
   controllers: [AuthController],
   providers: [
     SupabaseAuthGuard,
     OptionalSupabaseAuthGuard,
+    TermsAcceptanceGuard,
     CompleteProfileGuard,
     SuperAdminGuard,
     AuthService,
@@ -22,6 +25,7 @@ import { MethodVariant } from '../methods/entities/variant.entity';
   exports: [
     SupabaseAuthGuard,
     OptionalSupabaseAuthGuard,
+    TermsAcceptanceGuard,
     CompleteProfileGuard,
     SuperAdminGuard,
     AuthService,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -3,11 +3,13 @@ import { Repository } from 'typeorm';
 import { AuthService } from './auth.service';
 import { User } from './entities/user.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
+import { UserTermsAcceptance } from './entities/user-terms-acceptance.entity';
 
 describe('AuthService', () => {
   let service: AuthService;
   let repo: jest.Mocked<Pick<Repository<User>, 'findOne' | 'create' | 'save'>>;
   let likesRepo: jest.Mocked<Pick<Repository<MethodVariant>, 'createQueryBuilder'>>;
+  let termsRepo: jest.Mocked<Pick<Repository<UserTermsAcceptance>, 'findOne' | 'create' | 'save'>>;
   let likesQueryBuilder: {
     where: jest.Mock;
     getCount: jest.Mock;
@@ -26,9 +28,15 @@ describe('AuthService', () => {
     likesRepo = {
       createQueryBuilder: jest.fn().mockReturnValue(likesQueryBuilder),
     };
+    termsRepo = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
     service = new AuthService(
       repo as unknown as Repository<User>,
       likesRepo as unknown as Repository<MethodVariant>,
+      termsRepo as unknown as Repository<UserTermsAcceptance>,
     );
   });
 
@@ -109,6 +117,28 @@ describe('AuthService', () => {
       { userId: 'a42cf41b-2e77-4478-aedf-6cb1f8bce205' },
     );
     expect(likes).toBe(7);
+  });
+
+  it('reports current terms as not accepted when there is no current acceptance', async () => {
+    termsRepo.findOne.mockResolvedValue(null);
+
+    await expect(service.getCurrentTermsStatusForUser('user-1')).resolves.toEqual({
+      currentVersion: 'v1',
+      accepted: false,
+    });
+  });
+
+  it('reports current terms as accepted only when the current version exists', async () => {
+    termsRepo.findOne.mockResolvedValue({
+      id: 'acceptance-1',
+      userId: 'user-1',
+      termsVersion: 'v1',
+    } as UserTermsAcceptance);
+
+    await expect(service.getCurrentTermsStatusForUser('user-1')).resolves.toEqual({
+      currentVersion: 'v1',
+      accepted: true,
+    });
   });
 
   it('normalizes and saves account username once', async () => {
@@ -228,5 +258,99 @@ describe('AuthService', () => {
         'account_user',
       ),
     ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('creates the current terms acceptance once', async () => {
+    const existing = {
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+      plan: 'free',
+      role: 'user',
+    } as User;
+    repo.findOne.mockResolvedValue(existing);
+    termsRepo.findOne.mockResolvedValueOnce(null);
+    termsRepo.create.mockReturnValue({
+      userId: 'user-1',
+      termsVersion: 'v1',
+    } as UserTermsAcceptance);
+    termsRepo.save.mockResolvedValue({
+      id: 'acceptance-1',
+      userId: 'user-1',
+      termsVersion: 'v1',
+    } as UserTermsAcceptance);
+
+    await expect(
+      service.acceptCurrentTerms({
+        id: 'user-1',
+        email: 'user@example.com',
+      }),
+    ).resolves.toEqual({
+      currentVersion: 'v1',
+      accepted: true,
+    });
+
+    expect(termsRepo.create).toHaveBeenCalledWith({
+      userId: 'user-1',
+      termsVersion: 'v1',
+    });
+  });
+
+  it('is idempotent when the current terms were already accepted', async () => {
+    const existing = {
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+      plan: 'free',
+      role: 'user',
+    } as User;
+    repo.findOne.mockResolvedValue(existing);
+    termsRepo.findOne.mockResolvedValue({
+      id: 'acceptance-1',
+      userId: 'user-1',
+      termsVersion: 'v1',
+    } as UserTermsAcceptance);
+
+    await expect(
+      service.acceptCurrentTerms({
+        id: 'user-1',
+        email: 'user@example.com',
+      }),
+    ).resolves.toEqual({
+      currentVersion: 'v1',
+      accepted: true,
+    });
+
+    expect(termsRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('treats duplicate current-version inserts as a successful idempotent acceptance', async () => {
+    const existing = {
+      id: 'user-1',
+      email: 'user@example.com',
+      accountUsername: null,
+      plan: 'free',
+      role: 'user',
+    } as User;
+    repo.findOne.mockResolvedValue(existing);
+    termsRepo.findOne.mockResolvedValueOnce(null);
+    termsRepo.create.mockReturnValue({
+      userId: 'user-1',
+      termsVersion: 'v1',
+    } as UserTermsAcceptance);
+    termsRepo.save.mockRejectedValue({
+      code: '23505',
+      constraint: 'uq_user_terms_acceptances_user_version',
+    });
+
+    await expect(
+      service.acceptCurrentTerms({
+        id: 'user-1',
+        email: 'user@example.com',
+      }),
+    ).resolves.toEqual({
+      currentVersion: 'v1',
+      accepted: true,
+    });
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,8 @@ import { Repository } from 'typeorm';
 import type { AuthenticatedUser } from './auth.types';
 import { User } from './entities/user.entity';
 import { MethodVariant } from '../methods/entities/variant.entity';
+import { UserTermsAcceptance } from './entities/user-terms-acceptance.entity';
+import { CURRENT_TERMS_VERSION } from './terms.constants';
 
 const ACCOUNT_USERNAME_MIN_LENGTH = 3;
 const ACCOUNT_USERNAME_MAX_LENGTH = 20;
@@ -28,14 +30,33 @@ export class AuthService {
     private readonly userRepo: Repository<User>,
     @InjectRepository(MethodVariant)
     private readonly variantRepo: Repository<MethodVariant>,
+    @InjectRepository(UserTermsAcceptance)
+    private readonly userTermsAcceptanceRepo: Repository<UserTermsAcceptance>,
   ) {}
+
+  async getCurrentTermsStatusForUser(
+    userId: string,
+  ): Promise<{ currentVersion: string; accepted: boolean }> {
+    const currentAcceptance = await this.userTermsAcceptanceRepo.findOne({
+      where: {
+        userId,
+        termsVersion: CURRENT_TERMS_VERSION,
+      },
+    });
+
+    return {
+      currentVersion: CURRENT_TERMS_VERSION,
+      accepted: Boolean(currentAcceptance),
+    };
+  }
 
   async getOrCreateUser(authUser: Pick<AuthenticatedUser, 'id' | 'email'>): Promise<User> {
     const existingUser = await this.userRepo.findOne({ where: { id: authUser.id } });
     const nextEmail = authUser.email ?? '';
+    let user: User;
 
     if (!existingUser) {
-      return this.userRepo.save(
+      user = await this.userRepo.save(
         this.userRepo.create({
           id: authUser.id,
           email: nextEmail,
@@ -44,14 +65,14 @@ export class AuthService {
           role: 'user',
         }),
       );
-    }
-
-    if (existingUser.email !== nextEmail) {
+    } else if (existingUser.email !== nextEmail) {
       existingUser.email = nextEmail;
-      return this.userRepo.save(existingUser);
+      user = await this.userRepo.save(existingUser);
+    } else {
+      user = existingUser;
     }
 
-    return existingUser;
+    return user;
   }
 
   async setAccountUsername(
@@ -88,6 +109,43 @@ export class AuthService {
       .createQueryBuilder('method_variant')
       .where(':userId = ANY(method_variant.liked_user_ids)', { userId })
       .getCount();
+  }
+
+  async acceptCurrentTerms(
+    authUser: Pick<AuthenticatedUser, 'id' | 'email'>,
+  ): Promise<{ currentVersion: string; accepted: boolean }> {
+    const user = await this.getOrCreateUser(authUser);
+    const existingAcceptance = await this.userTermsAcceptanceRepo.findOne({
+      where: {
+        userId: user.id,
+        termsVersion: CURRENT_TERMS_VERSION,
+      },
+    });
+
+    if (existingAcceptance) {
+      return {
+        currentVersion: CURRENT_TERMS_VERSION,
+        accepted: true,
+      };
+    }
+
+    try {
+      await this.userTermsAcceptanceRepo.save(
+        this.userTermsAcceptanceRepo.create({
+          userId: user.id,
+          termsVersion: CURRENT_TERMS_VERSION,
+        }),
+      );
+    } catch (error) {
+      if (!this.isTermsAcceptanceConflictError(error)) {
+        throw error;
+      }
+    }
+
+    return {
+      currentVersion: CURRENT_TERMS_VERSION,
+      accepted: true,
+    };
   }
 
   private normalizeAccountUsername(value: string): string {
@@ -130,6 +188,24 @@ export class AuthService {
       candidate.constraint === 'users_account_username_unique_ci' ||
       candidate.constraint === 'idx_users_account_username_unique_ci' ||
       (typeof candidate.detail === 'string' && candidate.detail.includes('account_username'))
+    );
+  }
+
+  private isTermsAcceptanceConflictError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const candidate = error as { code?: unknown; constraint?: unknown; detail?: unknown };
+    if (candidate.code !== '23505') {
+      return false;
+    }
+
+    return (
+      candidate.constraint === 'uq_user_terms_acceptances_user_version' ||
+      (typeof candidate.detail === 'string' &&
+        candidate.detail.includes('user_id') &&
+        candidate.detail.includes('terms_version'))
     );
   }
 }

--- a/src/auth/entities/user-terms-acceptance.entity.ts
+++ b/src/auth/entities/user-terms-acceptance.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity({ schema: 'public', name: 'user_terms_acceptances' })
+@Unique('uq_user_terms_acceptances_user_version', ['userId', 'termsVersion'])
+export class UserTermsAcceptance {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ name: 'terms_version', type: 'text' })
+  termsVersion: string;
+
+  @CreateDateColumn({ name: 'accepted_at', type: 'timestamptz' })
+  acceptedAt: Date;
+}

--- a/src/auth/terms-acceptance-required.exception.ts
+++ b/src/auth/terms-acceptance-required.exception.ts
@@ -1,0 +1,13 @@
+import { ForbiddenException } from '@nestjs/common';
+
+export const TERMS_ACCEPTANCE_REQUIRED_ERROR_CODE = 'TERMS_ACCEPTANCE_REQUIRED';
+export const TERMS_ACCEPTANCE_REQUIRED_MESSAGE =
+  'You must accept the current Terms of Service before using this service.';
+
+export function createTermsAcceptanceRequiredException(currentVersion: string): ForbiddenException {
+  return new ForbiddenException({
+    code: TERMS_ACCEPTANCE_REQUIRED_ERROR_CODE,
+    message: TERMS_ACCEPTANCE_REQUIRED_MESSAGE,
+    currentVersion,
+  });
+}

--- a/src/auth/terms-acceptance.guard.spec.ts
+++ b/src/auth/terms-acceptance.guard.spec.ts
@@ -1,0 +1,72 @@
+import { UnauthorizedException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { TERMS_ACCEPTANCE_REQUIRED_ERROR_CODE } from './terms-acceptance-required.exception';
+import type { AuthService } from './auth.service';
+import { TermsAcceptanceGuard } from './terms-acceptance.guard';
+
+function createHttpExecutionContext(request: Record<string, unknown>): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as ExecutionContext;
+}
+
+describe('TermsAcceptanceGuard', () => {
+  it('rejects when authenticated user context is missing', async () => {
+    const guard = new TermsAcceptanceGuard({} as AuthService);
+
+    await expect(guard.canActivate(createHttpExecutionContext({}))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects when current terms are not accepted', async () => {
+    const authService = {
+      getOrCreateUser: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'user@example.com',
+      }),
+      getCurrentTermsStatusForUser: jest.fn().mockResolvedValue({
+        currentVersion: 'v1',
+        accepted: false,
+      }),
+    } as unknown as AuthService;
+    const guard = new TermsAcceptanceGuard(authService);
+
+    await expect(
+      guard.canActivate(
+        createHttpExecutionContext({
+          user: { id: 'user-1', email: 'user@example.com' },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      response: {
+        code: TERMS_ACCEPTANCE_REQUIRED_ERROR_CODE,
+        currentVersion: 'v1',
+      },
+    });
+  });
+
+  it('allows access when current terms are accepted', async () => {
+    const authService = {
+      getOrCreateUser: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'user@example.com',
+      }),
+      getCurrentTermsStatusForUser: jest.fn().mockResolvedValue({
+        currentVersion: 'v1',
+        accepted: true,
+      }),
+    } as unknown as AuthService;
+    const guard = new TermsAcceptanceGuard(authService);
+
+    await expect(
+      guard.canActivate(
+        createHttpExecutionContext({
+          user: { id: 'user-1', email: 'user@example.com' },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/src/auth/terms-acceptance.guard.ts
+++ b/src/auth/terms-acceptance.guard.ts
@@ -1,0 +1,33 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import type { Request } from 'express';
+import type { AuthenticatedUser } from './auth.types';
+import { AuthService } from './auth.service';
+import { createTermsAcceptanceRequiredException } from './terms-acceptance-required.exception';
+
+type RequestWithUser = Request & { user?: AuthenticatedUser };
+
+@Injectable()
+export class TermsAcceptanceGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<RequestWithUser>();
+    const authUser = req.user;
+
+    if (!authUser?.id) {
+      throw new UnauthorizedException('Missing authenticated user context');
+    }
+
+    const user = await this.authService.getOrCreateUser({
+      id: authUser.id,
+      email: authUser.email,
+    });
+    const termsStatus = await this.authService.getCurrentTermsStatusForUser(user.id);
+
+    if (!termsStatus.accepted) {
+      throw createTermsAcceptanceRequiredException(termsStatus.currentVersion);
+    }
+
+    return true;
+  }
+}

--- a/src/auth/terms.constants.ts
+++ b/src/auth/terms.constants.ts
@@ -1,0 +1,1 @@
+export const CURRENT_TERMS_VERSION = 'v1';

--- a/src/items/items.controller.ts
+++ b/src/items/items.controller.ts
@@ -28,6 +28,7 @@ import { ItemsService } from './items.service';
 import { BulkUpsertDto, CreateItemDto, UpdateItemDto } from './dto';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { TermsAcceptanceGuard } from '../auth/terms-acceptance.guard';
 
 const SORT_WHITELIST = new Set([
   'id',
@@ -208,7 +209,7 @@ export class ItemsController {
   }
 
   @Post()
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Create item', description: 'Creates a new item.' })
   @ApiCreatedResponse({ description: 'Item created', schema: { example: ITEM_EXAMPLE } })
@@ -219,7 +220,7 @@ export class ItemsController {
   }
 
   @Patch(':id')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update item', description: 'Updates an existing item.' })
   @ApiOkResponse({ description: 'Item updated', schema: { example: ITEM_EXAMPLE } })
@@ -230,7 +231,7 @@ export class ItemsController {
   }
 
   @Delete(':id')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @HttpCode(204)
   @ApiOperation({ summary: 'Delete item', description: 'Removes an item by id.' })
@@ -242,7 +243,7 @@ export class ItemsController {
   }
 
   @Post('bulk-upsert')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Bulk upsert items',

--- a/src/methods/methods.controller.spec.ts
+++ b/src/methods/methods.controller.spec.ts
@@ -9,6 +9,7 @@ import type { Request } from 'express';
 import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { TermsAcceptanceGuard } from '../auth/terms-acceptance.guard';
 import { MethodsController } from './methods.controller';
 import type { MethodsService } from './methods.service';
 
@@ -22,12 +23,12 @@ describe('MethodsController guard metadata', () => {
   ];
 
   it.each(writeRoutes)(
-    'requires SupabaseAuthGuard and SuperAdminGuard for %s endpoint',
+    'requires SupabaseAuthGuard, TermsAcceptanceGuard and SuperAdminGuard for %s endpoint',
     (methodName) => {
       const handler = MethodsController.prototype[methodName];
       const guards = Reflect.getMetadata(GUARDS_METADATA, handler) as unknown[];
 
-      expect(guards).toEqual([SupabaseAuthGuard, SuperAdminGuard]);
+      expect(guards).toEqual([SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard]);
     },
   );
 });
@@ -70,7 +71,7 @@ describe('MethodsController skills summary endpoint', () => {
 });
 
 describe('MethodsController skill roadmap endpoint', () => {
-  it('requires SupabaseAuthGuard and CompleteProfileGuard for the roadmap endpoint', () => {
+  it('requires SupabaseAuthGuard, TermsAcceptanceGuard and CompleteProfileGuard for the roadmap endpoint', () => {
     const descriptor = Object.getOwnPropertyDescriptor(
       MethodsController.prototype,
       'findSkillRoadmap',
@@ -81,7 +82,7 @@ describe('MethodsController skill roadmap endpoint', () => {
     const handler = descriptor?.value as object;
     const guards = Reflect.getMetadata(GUARDS_METADATA, handler) as unknown[];
 
-    expect(guards).toEqual([SupabaseAuthGuard, CompleteProfileGuard]);
+    expect(guards).toEqual([SupabaseAuthGuard, TermsAcceptanceGuard, CompleteProfileGuard]);
   });
 
   it('rejects query params outside the roadmap contract', async () => {

--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -27,6 +27,7 @@ import { CreateMethodDto, UpdateMethodDto, UpdateMethodBasicDto, UpdateVariantDt
 import { CompleteProfileGuard } from '../auth/complete-profile.guard';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { TermsAcceptanceGuard } from '../auth/terms-acceptance.guard';
 import type { AuthenticatedUser } from '../auth/auth.types';
 import { VARIANT_TAG_DEFINITIONS, VARIANT_TAG_QUERY_VALUES } from './variant-tags';
 
@@ -165,7 +166,7 @@ export class MethodsController {
   constructor(private readonly svc: MethodsService) {}
 
   @Post()
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Create method', description: 'Creates a new method.' })
   @ApiOkResponse({ description: 'Method created', schema: { example: { data: METHOD_EXAMPLE } } })
@@ -367,7 +368,7 @@ export class MethodsController {
   }
 
   @Get('skills/roadmap')
-  @UseGuards(SupabaseAuthGuard, CompleteProfileGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, CompleteProfileGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get a skill roadmap',
@@ -417,7 +418,10 @@ export class MethodsController {
     },
   })
   @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired bearer token' })
-  @ApiForbiddenResponse({ description: 'Complete your account username to use this endpoint' })
+  @ApiForbiddenResponse({
+    description:
+      'Accept the current Terms of Service and complete your account username to use this endpoint',
+  })
   async findSkillRoadmap(
     @Query('username') username?: string,
     @Query('skill') skill?: string,
@@ -585,7 +589,7 @@ export class MethodsController {
   }
 
   @Post('variant/:variantId/like')
-  @UseGuards(SupabaseAuthGuard, CompleteProfileGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, CompleteProfileGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Like method variant',
@@ -604,7 +608,7 @@ export class MethodsController {
   }
 
   @Delete('variant/:variantId/like')
-  @UseGuards(SupabaseAuthGuard, CompleteProfileGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, CompleteProfileGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Unlike method variant',
@@ -716,7 +720,7 @@ export class MethodsController {
   }
 
   @Put(':id')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update method', description: 'Updates an existing method.' })
   @ApiOkResponse({ description: 'Method updated', schema: { example: { data: METHOD_EXAMPLE } } })
@@ -728,7 +732,7 @@ export class MethodsController {
   }
 
   @Put(':id/basic')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Update method (basic)',
@@ -743,7 +747,7 @@ export class MethodsController {
   }
 
   @Put('variant/:id')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Update method variant',
@@ -764,7 +768,7 @@ export class MethodsController {
   }
 
   @Delete(':id')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete method', description: 'Removes a method by id.' })
   @ApiOkResponse({ description: 'Method removed', schema: { example: { data: null } } })

--- a/src/variant-snapshots/variant-snapshot.controller.spec.ts
+++ b/src/variant-snapshots/variant-snapshot.controller.spec.ts
@@ -1,10 +1,11 @@
 import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { TermsAcceptanceGuard } from '../auth/terms-acceptance.guard';
 import { VariantSnapshotController } from './variant-snapshot.controller';
 
 describe('VariantSnapshotController guard metadata', () => {
-  it('requires SupabaseAuthGuard and SuperAdminGuard to delete snapshots', () => {
+  it('requires SupabaseAuthGuard, TermsAcceptanceGuard and SuperAdminGuard to delete snapshots', () => {
     const descriptor = Object.getOwnPropertyDescriptor(
       VariantSnapshotController.prototype,
       'remove',
@@ -14,6 +15,6 @@ describe('VariantSnapshotController guard metadata', () => {
       descriptor?.value as (...args: unknown[]) => unknown,
     ) as unknown[];
 
-    expect(guards).toEqual([SupabaseAuthGuard, SuperAdminGuard]);
+    expect(guards).toEqual([SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard]);
   });
 });

--- a/src/variant-snapshots/variant-snapshot.controller.ts
+++ b/src/variant-snapshots/variant-snapshot.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/swagger';
 import { SupabaseAuthGuard } from '../auth/supabase-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { TermsAcceptanceGuard } from '../auth/terms-acceptance.guard';
 import { VariantSnapshotService } from './variant-snapshot.service';
 
 @ApiTags('variant-snapshots')
@@ -17,7 +18,7 @@ export class VariantSnapshotController {
   constructor(private readonly svc: VariantSnapshotService) {}
 
   @Delete(':id')
-  @UseGuards(SupabaseAuthGuard, SuperAdminGuard)
+  @UseGuards(SupabaseAuthGuard, TermsAcceptanceGuard, SuperAdminGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete variant snapshot', description: 'Removes a snapshot by id.' })
   @ApiOkResponse({ description: 'Snapshot removed', schema: { example: { data: null } } })

--- a/test/utils/create-test-app.ts
+++ b/test/utils/create-test-app.ts
@@ -16,6 +16,7 @@ import { VariantHistoryDaily } from '../../src/methods/entities/variant-history-
 import { VariantSnapshot } from '../../src/methods/entities/variant-snapshot.entity';
 import { VariantIoItemSnapshot } from '../../src/methods/entities/io-item-snapshot.entity';
 import { User } from '../../src/auth/entities/user.entity';
+import { UserTermsAcceptance } from '../../src/auth/entities/user-terms-acceptance.entity';
 import { ItemVolumeBucket } from '../../src/item-volumes/entities/item-volume-bucket.entity';
 import { CatalogsModule } from '../../src/catalogs/catalogs.module';
 import { AchievementDiary } from '../../src/catalogs/entities/achievement-diary.entity';
@@ -75,6 +76,7 @@ export const createTestApp = async (): Promise<TestApp> => {
           VariantSnapshot,
           VariantIoItemSnapshot,
           User,
+          UserTermsAcceptance,
           ItemVolumeBucket,
           AchievementDiary,
           Quest,


### PR DESCRIPTION
feat: add completed account username onboarding and enforce it across methods/admin routes

This branch introduces support for completing and storing an authenticated user's account username via the Supabase auth flow. It also enforces profile completion for protected methods and admin routes that require a completed account username.

Highlights:
- Add `POST /me/account-username` endpoint for username completion
- Persist normalized, lowercase `account_username` on the user record
- Add database migration and unique case-insensitive username index
- Add `CompleteProfileGuard` and enforce it for admin and methods endpoints
- Refine methods service auth handling to return structured account username errors
- Refactor presence service tests for stable timers and mocks
