### PR TITLE
fix: address account deletion and method review findings

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -26,7 +26,7 @@ describe('AuthService', () => {
   let termsRepo: jest.Mocked<Pick<Repository<UserTermsAcceptance>, 'findOne' | 'create' | 'save'>>;
   let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
   let dataSource: { transaction: jest.MockedFunction<TransactionRunner> };
-  let redisClient: { set: jest.Mock; zrem: jest.Mock };
+  let redisClient: { set: jest.Mock; del: jest.Mock; zrem: jest.Mock };
   let redisService: jest.Mocked<Pick<RedisService, 'getClient'>>;
   let likesQueryBuilder: {
     where: jest.Mock;
@@ -60,6 +60,7 @@ describe('AuthService', () => {
     };
     redisClient = {
       set: jest.fn().mockResolvedValue('OK'),
+      del: jest.fn().mockResolvedValue(1),
       zrem: jest.fn().mockResolvedValue(1),
     };
     redisService = {
@@ -435,6 +436,12 @@ describe('AuthService', () => {
     >;
 
     expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(redisClient.set.mock.invocationCallOrder[0]).toBeLessThan(
+      (global.fetch as jest.MockedFunction<typeof fetch>).mock.invocationCallOrder[0],
+    );
+    expect(
+      (global.fetch as jest.MockedFunction<typeof fetch>).mock.invocationCallOrder[0],
+    ).toBeLessThan(dataSource.transaction.mock.invocationCallOrder[0]);
     expect(queryCalls).toHaveLength(4);
     expect(String(queryCalls[0][0])).toContain('UPDATE method_variants');
     expect(queryCalls[0][1]).toEqual(['user-1']);
@@ -530,6 +537,29 @@ describe('AuthService', () => {
       BadGatewayException,
     );
 
-    expect(redisClient.set).not.toHaveBeenCalled();
+    expect(redisClient.set).toHaveBeenCalledTimes(1);
+    expect(redisClient.del).toHaveBeenCalledWith(buildDeletedUserAuthKey('user-1'));
+    expect(dataSource.transaction).not.toHaveBeenCalled();
+  });
+
+  it('does not delete the Supabase or Postgres user when the auth tombstone cannot be stored', async () => {
+    configService.get.mockImplementation((key: string) => {
+      switch (key) {
+        case 'SUPABASE_PROJECT_URL':
+          return 'https://example.supabase.co';
+        case 'SUPABASE_SERVICE_ROLE_KEY':
+          return 'service-role-key';
+        default:
+          return undefined;
+      }
+    });
+    redisClient.set.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    await expect(service.deleteAuthenticatedUser({ id: 'user-1' })).rejects.toThrow(
+      'redis unavailable',
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(dataSource.transaction).not.toHaveBeenCalled();
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -177,6 +177,15 @@ export class AuthService {
 
     const adminConfig = this.getSupabaseAdminConfig();
 
+    await this.markDeletedUserAccess(userId, authUser.exp);
+
+    try {
+      await this.deleteUserFromSupabase(userId, adminConfig);
+    } catch (error) {
+      await this.clearDeletedUserAccess(userId);
+      throw error;
+    }
+
     await this.dataSource.transaction(async (manager) => {
       await manager.query(
         `
@@ -202,8 +211,6 @@ export class AuthService {
       await manager.query(`DELETE FROM public.users WHERE id = $1`, [userId]);
     });
 
-    await this.deleteUserFromSupabase(userId, adminConfig);
-    await this.markDeletedUserAccess(userId, authUser.exp);
     await this.clearPresenceMembership(userId);
   }
 
@@ -278,13 +285,17 @@ export class AuthService {
   }
 
   private async markDeletedUserAccess(userId: string, exp: unknown): Promise<void> {
+    await this.redisService
+      .getClient()
+      .set(buildDeletedUserAuthKey(userId), '1', 'EX', resolveDeletedUserAuthTtlSeconds(exp));
+  }
+
+  private async clearDeletedUserAccess(userId: string): Promise<void> {
     try {
-      await this.redisService
-        .getClient()
-        .set(buildDeletedUserAuthKey(userId), '1', 'EX', resolveDeletedUserAuthTtlSeconds(exp));
+      await this.redisService.getClient().del(buildDeletedUserAuthKey(userId));
     } catch (error) {
       this.logger.warn(
-        `Could not store deleted-user auth tombstone for ${userId}: ${this.stringifyError(error)}`,
+        `Could not remove deleted-user auth tombstone for ${userId}: ${this.stringifyError(error)}`,
       );
     }
   }

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -1359,6 +1359,8 @@ export class MethodsService implements OnModuleDestroy {
     );
     const userInfo = query.player;
     const filters = this.buildListFilters(query);
+    filters.isOfficial ??= true;
+    await this.assertCanUseUnofficialMethodsFilter(filters.isOfficial, authenticatedUserId);
     if (filters.enabled === false) {
       await this.assertSuperAdminForDisabledMethods(query.authorization);
     }
@@ -3334,6 +3336,7 @@ export class MethodsService implements OnModuleDestroy {
             slug,
             icon_id,
             iconSource,
+            actionType,
             clickIntensity,
             afkiness,
             riskLevel,
@@ -3349,6 +3352,7 @@ export class MethodsService implements OnModuleDestroy {
             slug,
             icon_id,
             iconSource,
+            actionType,
             xpHour,
             label,
             description,
@@ -3558,6 +3562,7 @@ export class MethodsService implements OnModuleDestroy {
             slug,
             icon_id,
             iconSource,
+            actionType,
             clickIntensity,
             afkiness,
             riskLevel,
@@ -3573,6 +3578,7 @@ export class MethodsService implements OnModuleDestroy {
             slug,
             icon_id,
             iconSource,
+            actionType,
             xpHour,
             label,
             description,


### PR DESCRIPTION
Addresses all four unresolved PR #95 findings:

- Store the deletion tombstone before Supabase deletion and require that write to succeed; revert it when Supabase deletion fails.
- Delete local Postgres data only after Supabase deletion succeeds.
- Default trending profit to official methods and keep the unofficial-access check.
- Preserve actionType in search and trending enrichment responses.

Adds regression coverage for deletion ordering and required tombstone persistence.