### PR TITLE
fix(prices): send OSRS Wiki user agent

### DIFF
--- a/pr_msg.md
+++ b/pr_msg.md
@@ -1,23 +1,21 @@
 ## Summary
 
-- Add authenticated feedback submission with validation, rate limiting, and email notifications.
-- Add super-admin feedback listing, detail retrieval, and status updates.
-- Add the feedback database schema and document the required SMTP configuration.
+- Send the configured OSRS Wiki user agent when refreshing the latest item prices, with a descriptive fallback.
+- Replace verbose Axios error-object logging with compact HTTP error details.
+- Add coverage for configured and fallback request headers plus HTTP error logging.
 
 ## User-facing changelog
 
-- Signed-in users can now submit feature requests, bug reports, and other feedback directly from RS Methods.
+- Fixed an issue that could prevent item prices and method profits from refreshing.
 
 ## How to test
 
 - `npm run lint`
 - `npm test`
 - `npm run build`
-- Apply `sql/2026-08-25-create-feedback.sql` to the TST database.
-- Configure the SMTP variables from `.env.example`, then submit `POST /feedback` as a signed-in user with accepted terms and an account username.
-- As a `super_admin`, verify `GET /feedback`, `GET /feedback/:id`, and `PATCH /feedback/:id` return and update submitted feedback.
 
 ## Notes
 
 - Base branch: `develop`
 - Target environment: `TST`
+- No cache, profit calculation, or scheduled job logic changes.

--- a/src/prices/prices.service.spec.ts
+++ b/src/prices/prices.service.spec.ts
@@ -1,9 +1,11 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { HttpModule } from '@nestjs/axios';
+import { HttpService } from '@nestjs/axios';
+import { Logger } from '@nestjs/common';
 import { PricesService } from './prices.service';
 import { ConfigService } from '@nestjs/config';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { of, throwError } from 'rxjs';
+import { Repository } from 'typeorm';
 import { ItemPriceRule } from './entities/item-price-rule.entity';
+import { RedisService } from '../redis/redis.service';
 
 jest.mock('ioredis', () => ({
   __esModule: true,
@@ -15,27 +17,67 @@ jest.mock('ioredis', () => ({
 
 describe('PricesService', () => {
   let service: PricesService;
+  const httpGet = jest.fn();
+  const configGet = jest.fn();
+  const redisCall = jest.fn();
+  const priceRuleFind = jest.fn();
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [HttpModule],
-      providers: [
-        PricesService,
-        {
-          provide: ConfigService,
-          useValue: { get: jest.fn().mockReturnValue('redis://localhost:6379') },
-        },
-        {
-          provide: getRepositoryToken(ItemPriceRule),
-          useValue: { find: jest.fn().mockResolvedValue([]) },
-        },
-      ],
-    }).compile();
-
-    service = module.get<PricesService>(PricesService);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configGet.mockImplementation((key: string) =>
+      key === 'SCHEDULED_JOBS_ENABLED' ? 'false' : undefined,
+    );
+    priceRuleFind.mockResolvedValue([]);
+    service = new PricesService(
+      { get: httpGet } as unknown as HttpService,
+      { get: configGet } as unknown as ConfigService,
+      { find: priceRuleFind } as unknown as Repository<ItemPriceRule>,
+      { getClient: () => ({ call: redisCall }) } as unknown as RedisService,
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('sends the configured OSRS Wiki user agent when fetching prices', async () => {
+    configGet.mockImplementation((key: string) =>
+      key === 'OSRS_WIKI_USER_AGENT' ? 'RSMethods production contact@example.com' : undefined,
+    );
+    httpGet.mockReturnValue(of({ data: { data: {} } }));
+
+    await service.fetchPrices();
+
+    expect(httpGet).toHaveBeenCalledWith('https://prices.runescape.wiki/api/v1/osrs/latest', {
+      headers: { 'User-Agent': 'RSMethods production contact@example.com' },
+    });
+  });
+
+  it('uses a descriptive fallback user agent when none is configured', async () => {
+    httpGet.mockReturnValue(of({ data: { data: {} } }));
+
+    await service.fetchPrices();
+
+    expect(httpGet).toHaveBeenCalledWith('https://prices.runescape.wiki/api/v1/osrs/latest', {
+      headers: { 'User-Agent': 'RSMethods/1.0 (contact: contact@rsmethods.com)' },
+    });
+  });
+
+  it('logs compact HTTP error details without the Axios error object', async () => {
+    const loggerError = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const error = Object.assign(new Error('Request failed with status code 403'), {
+      response: {
+        status: 403,
+        data: { error: 'Forbidden', reason: 'Missing User-Agent' },
+      },
+    });
+    httpGet.mockReturnValue(throwError(() => error));
+
+    await service.fetchPrices();
+
+    expect(loggerError).toHaveBeenCalledWith(
+      'Error fetching prices: status=403 message=Request failed with status code 403 responseData={"error":"Forbidden","reason":"Missing User-Agent"}',
+    );
+    expect(loggerError.mock.calls[0]).toHaveLength(1);
   });
 });

--- a/src/prices/prices.service.ts
+++ b/src/prices/prices.service.ts
@@ -10,6 +10,9 @@ import { ItemPriceRule, ItemPriceRuleType } from './entities/item-price-rule.ent
 import { parseBooleanEnv } from '../common/utils/parse-boolean-env';
 import { RedisService } from '../redis/redis.service';
 
+const DEFAULT_USER_AGENT = 'RSMethods/1.0 (contact: contact@rsmethods.com)';
+const MAX_LOGGED_RESPONSE_DATA_LENGTH = 500;
+
 interface Price {
   high?: number;
   highTime?: number;
@@ -80,8 +83,12 @@ export class PricesService implements OnModuleInit {
 
   async fetchPrices(forceFull = false) {
     try {
+      const userAgent =
+        this.config.get<string>('OSRS_WIKI_USER_AGENT')?.trim() || DEFAULT_USER_AGENT;
       const { data } = await firstValueFrom(
-        this.http.get<{ data: Record<string, Price> }>(this.api),
+        this.http.get<{ data: Record<string, Price> }>(this.api, {
+          headers: { 'User-Agent': userAgent },
+        }),
       );
 
       const changedEntries: Array<[string, Price]> = [];
@@ -139,8 +146,64 @@ export class PricesService implements OnModuleInit {
 
       this.isFirstFetch = false;
     } catch (error) {
-      this.logger.error('Error fetching prices', error);
+      this.logger.error(this.formatFetchError(error));
     }
+  }
+
+  private formatFetchError(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    const response = this.getHttpErrorResponse(error);
+    const details = [`message=${message}`];
+
+    if (response) {
+      details.unshift(`status=${response.status}`);
+      const responseData = this.summarizeResponseData(response.data);
+      if (responseData) {
+        details.push(`responseData=${responseData}`);
+      }
+    }
+
+    return `Error fetching prices: ${details.join(' ')}`;
+  }
+
+  private getHttpErrorResponse(
+    error: unknown,
+  ): { status: number | undefined; data: unknown } | undefined {
+    if (!error || typeof error !== 'object' || !('response' in error)) {
+      return undefined;
+    }
+
+    const response = error.response;
+    if (!response || typeof response !== 'object') {
+      return undefined;
+    }
+
+    const { status, data } = response as { status?: unknown; data?: unknown };
+    return {
+      status: typeof status === 'number' ? status : undefined,
+      data,
+    };
+  }
+
+  private summarizeResponseData(data: unknown): string | undefined {
+    if (data === undefined || data === null || data === '') {
+      return undefined;
+    }
+
+    let serialized: string;
+    if (typeof data === 'string') {
+      serialized = data;
+    } else {
+      try {
+        serialized = JSON.stringify(data);
+      } catch {
+        return '[unserializable]';
+      }
+    }
+
+    return serialized.length > MAX_LOGGED_RESPONSE_DATA_LENGTH
+      ? `${serialized.slice(0, MAX_LOGGED_RESPONSE_DATA_LENGTH)}…`
+      : serialized;
   }
 
   async getMany(ids: number[]) {


### PR DESCRIPTION
## Summary

- Add authenticated feedback submission with validation, rate limiting, and email notifications.
- Add super-admin feedback listing, detail retrieval, and status updates.
- Add the feedback database schema and document the required SMTP configuration.

## User-facing changelog

- Signed-in users can now submit feature requests, bug reports, and other feedback directly from RS Methods.

## How to test

- `npm run lint`
- `npm test`
- `npm run build`
- Apply `sql/2026-08-25-create-feedback.sql` to the TST database.
- Configure the SMTP variables from `.env.example`, then submit `POST /feedback` as a signed-in user with accepted terms and an account username.
- As a `super_admin`, verify `GET /feedback`, `GET /feedback/:id`, and `PATCH /feedback/:id` return and update submitted feedback.

## Notes

- Base branch: `develop`
- Target environment: `TST`
