### PR TITLE
fix(methods): correct skill roadmap results

### DIFF
--- a/src/methods/methods.controller.ts
+++ b/src/methods/methods.controller.ts
@@ -121,6 +121,9 @@ const ROADMAP_EXAMPLE = {
       currentExperience: 0,
       targetLevel: 99,
       targetExperience: 13034431,
+      experienceRemaining: 13034431,
+      goalReached: false,
+      message: null,
       totalHours: 42.5,
       averageAfkPercent: 76.2,
       totalProfit: {

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -105,4 +105,125 @@ describe('MethodsService player context', () => {
       relations: ['variants'],
     });
   });
+
+  it('scales roadmap material totals by hours instead of actions per hour', () => {
+    const redisService = {
+      getClient: jest.fn().mockReturnValue({}),
+    } as unknown as RedisService;
+    const service = new MethodsService(
+      {} as Repository<Method>,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      {} as Repository<MethodVariant>,
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      { get: jest.fn() } as unknown as ConfigService,
+      {} as Repository<Item>,
+      redisService,
+    );
+    const internals = service as unknown as {
+      buildSkillRoadmap: (
+        candidates: unknown[],
+        userInfo: unknown,
+        skill: string,
+        strategy: 'fastest' | 'profitable' | 'most_afk',
+        skillProgress: { level: number; experience: number; usesExactExperience: boolean },
+        targetLevel: number,
+      ) => {
+        totalInputs: Array<{ id: number; quantity: number }>;
+        totalOutputs: Array<{ id: number; quantity: number }>;
+      };
+    };
+    const candidate = {
+      method: {
+        id: 'method-1',
+        name: 'Prayer regeneration method',
+        slug: 'prayer-regeneration-method',
+        iconSource: 'item',
+        enabled: true,
+      },
+      variant: {
+        id: 'variant-1',
+        slug: 'prayer-regeneration',
+        iconSource: 'item',
+        xpPerHour: 258720,
+        actionsPerHour: 1960,
+        lowProfit: 0,
+        highProfit: 0,
+        tags: [],
+        inputs: [
+          { id: 21163, quantity: 30 },
+          { id: 29993, quantity: 1764 },
+          { id: 30100, quantity: 1960 },
+        ],
+        outputs: [{ id: 30125, quantity: 1544 }],
+      },
+    };
+
+    const roadmap = internals.buildSkillRoadmap(
+      [candidate],
+      {},
+      'herblore',
+      'fastest',
+      { level: 91, experience: 5910436, usesExactExperience: true },
+      99,
+    );
+
+    expect(roadmap.totalInputs).toEqual([
+      { id: 21163, quantity: 827 },
+      { id: 29993, quantity: 48573 },
+      { id: 30100, quantity: 53970 },
+    ]);
+    expect(roadmap.totalOutputs).toEqual([{ id: 30125, quantity: 42515 }]);
+  });
+
+  it('marks a roadmap as complete when the player already has the target experience', () => {
+    const redisService = {
+      getClient: jest.fn().mockReturnValue({}),
+    } as unknown as RedisService;
+    const service = new MethodsService(
+      {} as Repository<Method>,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      {} as Repository<MethodVariant>,
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      { get: jest.fn() } as unknown as ConfigService,
+      {} as Repository<Item>,
+      redisService,
+    );
+    const internals = service as unknown as {
+      buildSkillRoadmap: (
+        candidates: unknown[],
+        userInfo: unknown,
+        skill: string,
+        strategy: 'fastest' | 'profitable' | 'most_afk',
+        skillProgress: { level: number; experience: number; usesExactExperience: boolean },
+        targetLevel: number,
+      ) => {
+        experienceRemaining: number;
+        goalReached: boolean;
+        message: string | null;
+        ranges: unknown[];
+      };
+    };
+
+    const roadmap = internals.buildSkillRoadmap(
+      [],
+      {},
+      'fletching',
+      'profitable',
+      { level: 99, experience: 13043265, usesExactExperience: true },
+      99,
+    );
+
+    expect(roadmap).toMatchObject({
+      experienceRemaining: 0,
+      goalReached: true,
+      message: 'Target level 99 has already been reached.',
+      ranges: [],
+    });
+  });
 });

--- a/src/methods/methods.service.spec.ts
+++ b/src/methods/methods.service.spec.ts
@@ -34,6 +34,48 @@ describe('MethodsService player context', () => {
     ).rejects.toEqual(new BadRequestException('player is required'));
   });
 
+  it('returns a completed roadmap before discovering candidates', async () => {
+    const redisService = {
+      getClient: jest.fn().mockReturnValue({}),
+    } as unknown as RedisService;
+    const service = new MethodsService(
+      {} as Repository<Method>,
+      {} as Repository<MethodVariant>,
+      {} as Repository<VariantIoItem>,
+      {} as Repository<VariantHistory>,
+      {} as Repository<MethodVariant>,
+      {} as Repository<User>,
+      {} as VariantSnapshotService,
+      { get: jest.fn() } as unknown as ConfigService,
+      {} as Repository<Item>,
+      redisService,
+    );
+    const internals = service as unknown as {
+      findRoadmapCandidates: jest.Mock;
+    };
+    internals.findRoadmapCandidates = jest.fn();
+
+    const response = await service.skillRoadmapResponse({
+      skill: 'fletching',
+      strategy: 'profitable',
+      show_only_free_to_play: true,
+      player: {
+        levels: { fletching: 99 },
+        experience: { fletching: 13043265 },
+        quests: {},
+        achievement_diaries: {},
+      },
+    });
+
+    expect(internals.findRoadmapCandidates).not.toHaveBeenCalled();
+    expect(response.data.roadmap).toMatchObject({
+      experienceRemaining: 0,
+      goalReached: true,
+      message: 'Target level 99 has already been reached.',
+      ranges: [],
+    });
+  });
+
   it('counts only enabled official variants for each skill summary', async () => {
     const find = jest.fn().mockResolvedValue([
       {

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -1843,10 +1843,13 @@ export class MethodsService implements OnModuleDestroy {
   private accumulateRoadmapMaterialTotals(
     totals: Map<number, number>,
     items: RoadmapMaterialItem[],
-    actionsNeeded: number,
+    hours: number,
   ): void {
     for (const item of items) {
-      const nextQuantity = (totals.get(item.id) ?? 0) + actionsNeeded * item.quantity;
+      // Variant IO quantities represent the amount produced or consumed per hour.
+      // Do not multiply them by actionsPerHour: that would apply the hourly action
+      // rate twice and inflate totals by that rate.
+      const nextQuantity = (totals.get(item.id) ?? 0) + hours * item.quantity;
       totals.set(item.id, nextQuantity);
     }
   }
@@ -1950,6 +1953,9 @@ export class MethodsService implements OnModuleDestroy {
         currentExperience: skillProgress.experience,
         targetLevel,
         targetExperience,
+        experienceRemaining: 0,
+        goalReached: true,
+        message: `Target level ${targetLevel} has already been reached.`,
         totalHours: 0,
         averageAfkPercent: 0,
         totalProfit: { low: 0, high: 0 },
@@ -2008,23 +2014,8 @@ export class MethodsService implements OnModuleDestroy {
       const experienceNeeded = Math.max(0, experienceEnd - experienceStart);
       const hours = experienceNeeded / candidate.variant.xpPerHour;
       const afkPercent = this.getRoadmapAfkPercent(candidate.variant.afkiness);
-      const actionsPerHour = Number(candidate.variant.actionsPerHour);
-      const canComputeMaterials = Number.isFinite(actionsPerHour) && actionsPerHour > 0;
-
-      if (canComputeMaterials) {
-        const actionsNeeded = (experienceNeeded * actionsPerHour) / candidate.variant.xpPerHour;
-        this.accumulateRoadmapMaterialTotals(totalInputs, candidate.variant.inputs, actionsNeeded);
-        this.accumulateRoadmapMaterialTotals(
-          totalOutputs,
-          candidate.variant.outputs,
-          actionsNeeded,
-        );
-      } else {
-        const variantTitle = candidate.variant.label?.trim() || candidate.method.name;
-        warnings.push(
-          `Roadmap material totals are unavailable because actionsPerHour is missing for ${variantTitle} (levels ${level}-${levelEnd}).`,
-        );
-      }
+      this.accumulateRoadmapMaterialTotals(totalInputs, candidate.variant.inputs, hours);
+      this.accumulateRoadmapMaterialTotals(totalOutputs, candidate.variant.outputs, hours);
 
       ranges.push({
         levelStart: level,
@@ -2062,6 +2053,9 @@ export class MethodsService implements OnModuleDestroy {
       currentExperience: skillProgress.experience,
       targetLevel,
       targetExperience,
+      experienceRemaining: Math.max(0, targetExperience - skillProgress.experience),
+      goalReached: false,
+      message: null,
       totalHours,
       averageAfkPercent: totalHours > 0 ? weightedAfkSum / totalHours : 0,
       totalProfit,

--- a/src/methods/methods.service.ts
+++ b/src/methods/methods.service.ts
@@ -1522,14 +1522,12 @@ export class MethodsService implements OnModuleDestroy {
         `target_level must be greater than or equal to the player's current ${skill} level (${skillProgress.level})`,
       );
     }
-    const roadmapCandidates = await this.findRoadmapCandidates(
-      skill,
-      enabled,
-      ignoredTags,
-      showOnlyFreeToPlay,
-    );
+    const goalReached = skillProgress.experience >= this.getExperienceForLevel(targetLevel);
+    const roadmapCandidates = goalReached
+      ? []
+      : await this.findRoadmapCandidates(skill, enabled, ignoredTags, showOnlyFreeToPlay);
 
-    if (roadmapCandidates.length === 0) {
+    if (!goalReached && roadmapCandidates.length === 0) {
       throw new NotFoundException(
         `No roadmap variants are available for skill ${skill} with the selected filters`,
       );


### PR DESCRIPTION
## Summary

- Correct skill-roadmap material totals to use the per-hour quantities provided by method variants.
- Return explicit goal-progress fields when a player has already reached the requested target level.
- Cover material-total scaling and completed-roadmap responses with unit tests.

## User-facing changelog

- Skill roadmaps now show accurate total materials needed for the selected training plan.
- Skill roadmaps now clearly indicate when your requested target level has already been reached.

## How to test

- `npm run lint`
- `npm test`
- `npm run build`

## Notes

No business logic changes beyond the skill-roadmap result corrections.
